### PR TITLE
feat(NODE-4541): implement legacy callback wrapper library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+node_modules/
 !mongodb-legacy.d.ts
 .vscode/
 *.tgz

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -2,11 +2,12 @@
   "$schema": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/mocharc.json",
   "extension": ["js", "ts"],
   "recursive": true,
-  "failZero": false,
+  "failZero": true,
   "sort": true,
   "color": true,
   "require": [
     "source-map-support/register",
-    "ts-node/register"
+    "ts-node/register",
+    "test/hooks/addons.js"
   ]
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,79 @@
 'use strict';
 
-throw new Error('Work In Progress - Not intended for use at this time');
+const mongodb = require('mongodb');
+
+const { makeLegacyMongoClient } = require('./legacy_wrappers/mongo_client');
+const { makeLegacyDb } = require('./legacy_wrappers/db');
+const { makeLegacyCollection } = require('./legacy_wrappers/collection');
+const { makeLegacyAdmin } = require('./legacy_wrappers/admin');
+const {
+  makeLegacyAggregationCursor,
+  makeLegacyFindCursor,
+  makeLegacyListCollectionsCursor,
+  makeLegacyListIndexesCursor
+} = require('./legacy_wrappers/cursors');
+const {
+  makeLegacyGridFSBucket,
+  makeLegacyGridFSBucketWriteStream
+} = require('./legacy_wrappers/gridfs');
+const { makeLegacyChangeStream } = require('./legacy_wrappers/change_stream');
+const { makeLegacyClientSession } = require('./legacy_wrappers/session');
+const {
+  makeLegacyUnorderedBulkOperation,
+  makeLegacyOrderedBulkOperation
+} = require('./legacy_wrappers/bulk');
+
+/** @type {import('..')} */
+module.exports = Object.create(null);
+Object.defineProperty(module.exports, '__esModule', { value: true });
+
+const classesWithAsyncAPIs = new Map([
+  ['Admin', makeLegacyAdmin],
+  ['FindCursor', makeLegacyFindCursor],
+  ['ListCollectionsCursor', makeLegacyListCollectionsCursor],
+  ['ListIndexesCursor', makeLegacyListIndexesCursor],
+  ['AggregationCursor', makeLegacyAggregationCursor],
+  ['ChangeStream', makeLegacyChangeStream],
+  ['Collection', makeLegacyCollection],
+  ['Db', makeLegacyDb],
+  ['GridFSBucket', makeLegacyGridFSBucket],
+  ['ClientSession', makeLegacyClientSession],
+  ['MongoClient', makeLegacyMongoClient],
+
+  // Need to be exported top-level still
+  ['ClientSession', makeLegacyClientSession],
+  ['GridFSBucketWriteStream', makeLegacyGridFSBucketWriteStream],
+  ['OrderedBulkOperation', makeLegacyOrderedBulkOperation],
+  ['UnorderedBulkOperation', makeLegacyUnorderedBulkOperation]
+]);
+
+const TODO_SPECIAL_IMPORTS = new Map([
+  ['ClientSession', '/lib/sessions'],
+  ['GridFSBucketWriteStream', '/lib/gridfs/upload'],
+  ['OrderedBulkOperation', '/lib/bulk/ordered'],
+  ['UnorderedBulkOperation', '/lib/bulk/unordered']
+]);
+
+for (const [missingTopLevelClassName, location] of TODO_SPECIAL_IMPORTS) {
+  mongodb[missingTopLevelClassName] = require(`mongodb${location}`)[missingTopLevelClassName];
+}
+
+for (const [mongodbExportName, mongodbExportValue] of Object.entries(mongodb)) {
+  let makeLegacyClass = classesWithAsyncAPIs.get(mongodbExportName);
+  if (makeLegacyClass != null) {
+    const patchedClass = makeLegacyClass(mongodbExportValue);
+    Object.defineProperty(module.exports, mongodbExportName, {
+      enumerable: true,
+      get: function () {
+        return patchedClass;
+      }
+    });
+  } else {
+    Object.defineProperty(module.exports, mongodbExportName, {
+      enumerable: true,
+      get: function () {
+        return mongodbExportValue;
+      }
+    });
+  }
+}

--- a/src/legacy_wrappers/admin.js
+++ b/src/legacy_wrappers/admin.js
@@ -17,9 +17,9 @@ module.exports.makeLegacyAdmin = function (baseClass) {
           ? password
           : undefined;
       options =
-        typeof options !== 'function'
+        options != null && typeof options === 'object'
           ? options
-          : typeof password !== 'function'
+          : password != null && typeof password === 'object'
           ? password
           : undefined;
       return maybeCallback(super.addUser(username, password, options), callback);

--- a/src/legacy_wrappers/admin.js
+++ b/src/legacy_wrappers/admin.js
@@ -1,0 +1,136 @@
+'use strict';
+
+const { toLegacy, maybeCallback } = require('../utils');
+
+module.exports = Object.create(null);
+Object.defineProperty(module.exports, '__esModule', { value: true });
+
+module.exports.makeLegacyAdmin = function (baseClass) {
+  class LegacyAdmin extends baseClass {
+    addUser(username, password, options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : typeof password === 'function'
+          ? password
+          : undefined;
+      options =
+        typeof options !== 'function'
+          ? options
+          : typeof password !== 'function'
+          ? password
+          : undefined;
+      return maybeCallback(super.addUser(username, password, options), callback);
+    }
+
+    buildInfo(options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.buildInfo(options), callback);
+    }
+
+    command(command, options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.command(command, options), callback);
+    }
+
+    listDatabases(options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.listDatabases(options), callback);
+    }
+
+    ping(options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.ping(options), callback);
+    }
+
+    removeUser(username, options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.removeUser(username, options), callback);
+    }
+
+    replSetGetStatus(options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.replSetGetStatus(options), callback);
+    }
+
+    serverInfo(options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.serverInfo(options), callback);
+    }
+
+    serverStatus(options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.serverStatus(options), callback);
+    }
+
+    validateCollection(name, options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.validateCollection(name, options), callback);
+    }
+  }
+
+  Object.defineProperty(baseClass.prototype, toLegacy, {
+    enumerable: false,
+    value: function () {
+      return Object.setPrototypeOf(this, LegacyAdmin.prototype);
+    }
+  });
+
+  return LegacyAdmin;
+};

--- a/src/legacy_wrappers/bulk.js
+++ b/src/legacy_wrappers/bulk.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const { maybeCallback } = require('../utils');
+
+module.exports = Object.create(null);
+Object.defineProperty(module.exports, '__esModule', { value: true });
+
+module.exports.makeLegacyOrderedBulkOperation = function (baseClass) {
+  return class LegacyOrderedBulkOperation extends baseClass {
+    execute(options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.execute(options), callback);
+    }
+  };
+};
+
+module.exports.makeLegacyUnorderedBulkOperation = function (baseClass) {
+  return class LegacyUnorderedBulkOperation extends baseClass {
+    execute(options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.execute(options), callback);
+    }
+  };
+};

--- a/src/legacy_wrappers/change_stream.js
+++ b/src/legacy_wrappers/change_stream.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const { toLegacy, maybeCallback } = require('../utils');
+
+module.exports = Object.create(null);
+Object.defineProperty(module.exports, '__esModule', { value: true });
+
+module.exports.makeLegacyChangeStream = function (baseClass) {
+  class LegacyChangeStream extends baseClass {
+    close(callback) {
+      return maybeCallback(super.close(), callback);
+    }
+    hasNext(callback) {
+      return maybeCallback(super.hasNext(), callback);
+    }
+    next(callback) {
+      return maybeCallback(super.next(), callback);
+    }
+    tryNext(callback) {
+      return maybeCallback(super.tryNext(), callback);
+    }
+  }
+
+  Object.defineProperty(baseClass.prototype, toLegacy, {
+    enumerable: false,
+    value: function () {
+      return Object.setPrototypeOf(this, LegacyChangeStream.prototype);
+    }
+  });
+
+  return LegacyChangeStream;
+};

--- a/src/legacy_wrappers/collection.js
+++ b/src/legacy_wrappers/collection.js
@@ -194,18 +194,15 @@ module.exports.makeLegacyCollection = function (baseClass) {
       return maybeCallback(super.findOneAndReplace(filter, replacement, options), callback);
     }
 
-    findOneAndUpdate(filter, options, callback) {
+    findOneAndUpdate(filter, update, options, callback) {
       callback =
         typeof callback === 'function'
           ? callback
           : typeof options === 'function'
           ? options
-          : typeof filter === 'function'
-          ? filter
           : undefined;
       options = typeof options !== 'function' ? options : undefined;
-      filter = typeof filter !== 'function' ? filter : undefined;
-      return maybeCallback(super.findOneAndUpdate(filter, options), callback);
+      return maybeCallback(super.findOneAndUpdate(filter, update, options), callback);
     }
 
     indexExists(indexes, options, callback) {

--- a/src/legacy_wrappers/collection.js
+++ b/src/legacy_wrappers/collection.js
@@ -183,18 +183,15 @@ module.exports.makeLegacyCollection = function (baseClass) {
       return maybeCallback(super.findOneAndDelete(filter, options), callback);
     }
 
-    findOneAndReplace(filter, options, callback) {
+    findOneAndReplace(filter, replacement, options, callback) {
       callback =
         typeof callback === 'function'
           ? callback
           : typeof options === 'function'
           ? options
-          : typeof filter === 'function'
-          ? filter
           : undefined;
       options = typeof options !== 'function' ? options : undefined;
-      filter = typeof filter !== 'function' ? filter : undefined;
-      return maybeCallback(super.findOneAndReplace(filter, options), callback);
+      return maybeCallback(super.findOneAndReplace(filter, replacement, options), callback);
     }
 
     findOneAndUpdate(filter, options, callback) {

--- a/src/legacy_wrappers/collection.js
+++ b/src/legacy_wrappers/collection.js
@@ -1,0 +1,419 @@
+'use strict';
+
+const { toLegacy, maybeCallback } = require('../utils');
+
+module.exports = Object.create(null);
+Object.defineProperty(module.exports, '__esModule', { value: true });
+
+module.exports.makeLegacyCollection = function (baseClass) {
+  class LegacyCollection extends baseClass {
+    // async APIs
+    bulkWrite(operations, options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.bulkWrite(operations, options), callback);
+    }
+
+    count(filter, options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : typeof filter === 'function'
+          ? filter
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      filter = typeof filter !== 'function' ? filter : undefined;
+      return maybeCallback(super.count(filter, options), callback);
+    }
+
+    countDocuments(filter, options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : typeof filter === 'function'
+          ? filter
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      filter = typeof filter !== 'function' ? filter : undefined;
+      return maybeCallback(super.countDocuments(filter, options), callback);
+    }
+
+    estimatedDocumentCount(options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.estimatedDocumentCount(options), callback);
+    }
+
+    createIndex(indexSpec, options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.createIndex(indexSpec, options), callback);
+    }
+
+    createIndexes(indexSpecs, options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.createIndexes(indexSpecs, options), callback);
+    }
+
+    dropIndex(indexName, options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.dropIndex(indexName, options), callback);
+    }
+
+    dropIndexes(options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.dropIndexes(options), callback);
+    }
+
+    deleteMany(filter, options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : typeof filter === 'function'
+          ? filter
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      filter = typeof filter !== 'function' ? filter : undefined;
+      return maybeCallback(super.deleteMany(filter, options), callback);
+    }
+
+    deleteOne(filter, options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : typeof filter === 'function'
+          ? filter
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      filter = typeof filter !== 'function' ? filter : undefined;
+      return maybeCallback(super.deleteOne(filter, options), callback);
+    }
+
+    distinct(key, filter, options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : typeof filter === 'function'
+          ? filter
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      filter = typeof filter !== 'function' ? filter : undefined;
+      return maybeCallback(super.distinct(key, filter, options), callback);
+    }
+
+    drop(options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.drop(options), callback);
+    }
+
+    findOne(filter, options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : typeof filter === 'function'
+          ? filter
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      filter = typeof filter !== 'function' ? filter : undefined;
+      return maybeCallback(super.findOne(filter, options), callback);
+    }
+
+    findOneAndDelete(filter, options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : typeof filter === 'function'
+          ? filter
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      filter = typeof filter !== 'function' ? filter : undefined;
+      return maybeCallback(super.findOneAndDelete(filter, options), callback);
+    }
+
+    findOneAndReplace(filter, options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : typeof filter === 'function'
+          ? filter
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      filter = typeof filter !== 'function' ? filter : undefined;
+      return maybeCallback(super.findOneAndReplace(filter, options), callback);
+    }
+
+    findOneAndUpdate(filter, options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : typeof filter === 'function'
+          ? filter
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      filter = typeof filter !== 'function' ? filter : undefined;
+      return maybeCallback(super.findOneAndUpdate(filter, options), callback);
+    }
+
+    indexExists(indexes, options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.indexExists(indexes, options), callback);
+    }
+
+    indexInformation(options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.indexInformation(options), callback);
+    }
+
+    indexes(options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.indexes(options), callback);
+    }
+
+    insert(docs, options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.insert(docs, options), callback);
+    }
+
+    insertMany(docs, options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.insertMany(docs, options), callback);
+    }
+
+    insertOne(doc, options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.insertOne(doc, options), callback);
+    }
+
+    isCapped(options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.isCapped(options), callback);
+    }
+
+    mapReduce(map, reduce, options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.mapReduce(map, reduce, options), callback);
+    }
+
+    options(options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.options(options), callback);
+    }
+
+    remove(filter, options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.remove(filter, options), callback);
+    }
+
+    rename(newName, options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(
+        super.rename(newName, options).then(collection => collection[toLegacy]()),
+        callback
+      );
+    }
+
+    replaceOne(filter, replacement, options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.replaceOne(filter, replacement, options), callback);
+    }
+
+    stats(options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.stats(options), callback);
+    }
+
+    update(filter, update, options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.update(filter, update, options), callback);
+    }
+
+    updateMany(filter, update, options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.updateMany(filter, update, options), callback);
+    }
+
+    updateOne(filter, update, options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.updateOne(filter, update, options), callback);
+    }
+
+    // conversion APIs
+    aggregate(pipeline, options) {
+      return super.aggregate(pipeline, options)[toLegacy]();
+    }
+
+    find(filter, options) {
+      return super.find(filter, options)[toLegacy]();
+    }
+
+    listIndexes(options) {
+      return super.listIndexes(options)[toLegacy]();
+    }
+
+    watch(pipeline, options) {
+      return super.watch(pipeline, options)[toLegacy]();
+    }
+  }
+
+  Object.defineProperty(baseClass.prototype, toLegacy, {
+    enumerable: false,
+    value: function () {
+      return Object.setPrototypeOf(this, LegacyCollection.prototype);
+    }
+  });
+
+  return LegacyCollection;
+};

--- a/src/legacy_wrappers/cursors.js
+++ b/src/legacy_wrappers/cursors.js
@@ -6,75 +6,6 @@ const { toLegacy } = require('../utils');
 module.exports = Object.create(null);
 Object.defineProperty(module.exports, '__esModule', { value: true });
 
-const commonCursorFunctions = new Map([
-  [
-    'close',
-    function close(options, callback) {
-      callback =
-        typeof callback === 'function'
-          ? callback
-          : typeof options === 'function'
-          ? options
-          : undefined;
-      options = typeof options !== 'function' ? options : undefined;
-      return maybeCallback(
-        Object.getPrototypeOf(this.constructor.prototype).close.call(this, options),
-        callback
-      );
-    }
-  ],
-
-  [
-    'forEach',
-    function forEach(iterator, callback) {
-      return maybeCallback(
-        Object.getPrototypeOf(this.constructor.prototype).forEach.call(this, iterator),
-        callback
-      );
-    }
-  ],
-
-  [
-    'hasNext',
-    function hasNext(callback) {
-      return maybeCallback(
-        Object.getPrototypeOf(this.constructor.prototype).hasNext.call(this),
-        callback
-      );
-    }
-  ],
-
-  [
-    'next',
-    function next(callback) {
-      return maybeCallback(
-        Object.getPrototypeOf(this.constructor.prototype).next.call(this),
-        callback
-      );
-    }
-  ],
-
-  [
-    'toArray',
-    function toArray(callback) {
-      return maybeCallback(
-        Object.getPrototypeOf(this.constructor.prototype).toArray.call(this),
-        callback
-      );
-    }
-  ],
-
-  [
-    'tryNext',
-    function tryNext(callback) {
-      return maybeCallback(
-        Object.getPrototypeOf(this.constructor.prototype).tryNext.call(this),
-        callback
-      );
-    }
-  ]
-]);
-
 module.exports.makeLegacyFindCursor = function (baseClass) {
   class LegacyFindCursor extends baseClass {
     /** @deprecated Use `collection.estimatedDocumentCount` or `collection.countDocuments` instead */
@@ -99,10 +30,32 @@ module.exports.makeLegacyFindCursor = function (baseClass) {
       verbosity = typeof verbosity !== 'function' ? verbosity : undefined;
       return maybeCallback(super.explain(verbosity), callback);
     }
-  }
 
-  for (const [name, method] of commonCursorFunctions) {
-    Object.defineProperty(LegacyFindCursor.prototype, name, { enumerable: false, value: method });
+    close(options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.close(options), callback);
+    }
+    forEach(iterator, callback) {
+      return maybeCallback(super.forEach(iterator), callback);
+    }
+    hasNext(callback) {
+      return maybeCallback(super.hasNext(), callback);
+    }
+    next(callback) {
+      return maybeCallback(super.next(), callback);
+    }
+    toArray(callback) {
+      return maybeCallback(super.toArray(), callback);
+    }
+    tryNext(callback) {
+      return maybeCallback(super.tryNext(), callback);
+    }
   }
 
   Object.defineProperty(baseClass.prototype, toLegacy, {
@@ -116,13 +69,32 @@ module.exports.makeLegacyFindCursor = function (baseClass) {
 };
 
 module.exports.makeLegacyListCollectionsCursor = function (baseClass) {
-  class LegacyListCollectionsCursor extends baseClass {}
-
-  for (const [name, method] of commonCursorFunctions) {
-    Object.defineProperty(LegacyListCollectionsCursor.prototype, name, {
-      enumerable: false,
-      value: method
-    });
+  class LegacyListCollectionsCursor extends baseClass {
+    close(options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.close(options), callback);
+    }
+    forEach(iterator, callback) {
+      return maybeCallback(super.forEach(iterator), callback);
+    }
+    hasNext(callback) {
+      return maybeCallback(super.hasNext(), callback);
+    }
+    next(callback) {
+      return maybeCallback(super.next(), callback);
+    }
+    toArray(callback) {
+      return maybeCallback(super.toArray(), callback);
+    }
+    tryNext(callback) {
+      return maybeCallback(super.tryNext(), callback);
+    }
   }
 
   Object.defineProperty(baseClass.prototype, toLegacy, {
@@ -136,13 +108,32 @@ module.exports.makeLegacyListCollectionsCursor = function (baseClass) {
 };
 
 module.exports.makeLegacyListIndexesCursor = function (baseClass) {
-  class LegacyListIndexesCursor extends baseClass {}
-
-  for (const [name, method] of commonCursorFunctions) {
-    Object.defineProperty(LegacyListIndexesCursor.prototype, name, {
-      enumerable: false,
-      value: method
-    });
+  class LegacyListIndexesCursor extends baseClass {
+    close(options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.close(options), callback);
+    }
+    forEach(iterator, callback) {
+      return maybeCallback(super.forEach(iterator), callback);
+    }
+    hasNext(callback) {
+      return maybeCallback(super.hasNext(), callback);
+    }
+    next(callback) {
+      return maybeCallback(super.next(), callback);
+    }
+    toArray(callback) {
+      return maybeCallback(super.toArray(), callback);
+    }
+    tryNext(callback) {
+      return maybeCallback(super.tryNext(), callback);
+    }
   }
 
   Object.defineProperty(baseClass.prototype, toLegacy, {
@@ -167,13 +158,32 @@ module.exports.makeLegacyAggregationCursor = function (baseClass) {
       verbosity = typeof verbosity !== 'function' ? verbosity : undefined;
       return maybeCallback(super.explain(verbosity), callback);
     }
-  }
 
-  for (const [name, method] of commonCursorFunctions) {
-    Object.defineProperty(LegacyAggregationCursor.prototype, name, {
-      enumerable: false,
-      value: method
-    });
+    close(options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.close(options), callback);
+    }
+    forEach(iterator, callback) {
+      return maybeCallback(super.forEach(iterator), callback);
+    }
+    hasNext(callback) {
+      return maybeCallback(super.hasNext(), callback);
+    }
+    next(callback) {
+      return maybeCallback(super.next(), callback);
+    }
+    toArray(callback) {
+      return maybeCallback(super.toArray(), callback);
+    }
+    tryNext(callback) {
+      return maybeCallback(super.tryNext(), callback);
+    }
   }
 
   Object.defineProperty(baseClass.prototype, toLegacy, {

--- a/src/legacy_wrappers/cursors.js
+++ b/src/legacy_wrappers/cursors.js
@@ -1,0 +1,187 @@
+'use strict';
+
+const { maybeCallback } = require('../utils');
+const { toLegacy } = require('../utils');
+
+module.exports = Object.create(null);
+Object.defineProperty(module.exports, '__esModule', { value: true });
+
+const commonCursorFunctions = new Map([
+  [
+    'close',
+    function close(options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(
+        Object.getPrototypeOf(this.constructor.prototype).close.call(this, options),
+        callback
+      );
+    }
+  ],
+
+  [
+    'forEach',
+    function forEach(iterator, callback) {
+      return maybeCallback(
+        Object.getPrototypeOf(this.constructor.prototype).forEach.call(this, iterator),
+        callback
+      );
+    }
+  ],
+
+  [
+    'hasNext',
+    function hasNext(callback) {
+      return maybeCallback(
+        Object.getPrototypeOf(this.constructor.prototype).hasNext.call(this),
+        callback
+      );
+    }
+  ],
+
+  [
+    'next',
+    function next(callback) {
+      return maybeCallback(
+        Object.getPrototypeOf(this.constructor.prototype).next.call(this),
+        callback
+      );
+    }
+  ],
+
+  [
+    'toArray',
+    function toArray(callback) {
+      return maybeCallback(
+        Object.getPrototypeOf(this.constructor.prototype).toArray.call(this),
+        callback
+      );
+    }
+  ],
+
+  [
+    'tryNext',
+    function tryNext(callback) {
+      return maybeCallback(
+        Object.getPrototypeOf(this.constructor.prototype).tryNext.call(this),
+        callback
+      );
+    }
+  ]
+]);
+
+module.exports.makeLegacyFindCursor = function (baseClass) {
+  class LegacyFindCursor extends baseClass {
+    /** @deprecated Use `collection.estimatedDocumentCount` or `collection.countDocuments` instead */
+    count(options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.count(options), callback);
+    }
+
+    explain(verbosity, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof verbosity === 'function'
+          ? verbosity
+          : undefined;
+      verbosity = typeof verbosity !== 'function' ? verbosity : undefined;
+      return maybeCallback(super.explain(verbosity), callback);
+    }
+  }
+
+  for (const [name, method] of commonCursorFunctions) {
+    Object.defineProperty(LegacyFindCursor.prototype, name, { enumerable: false, value: method });
+  }
+
+  Object.defineProperty(baseClass.prototype, toLegacy, {
+    enumerable: false,
+    value: function () {
+      return Object.setPrototypeOf(this, LegacyFindCursor.prototype);
+    }
+  });
+
+  return LegacyFindCursor;
+};
+
+module.exports.makeLegacyListCollectionsCursor = function (baseClass) {
+  class LegacyListCollectionsCursor extends baseClass {}
+
+  for (const [name, method] of commonCursorFunctions) {
+    Object.defineProperty(LegacyListCollectionsCursor.prototype, name, {
+      enumerable: false,
+      value: method
+    });
+  }
+
+  Object.defineProperty(baseClass.prototype, toLegacy, {
+    enumerable: false,
+    value: function () {
+      return Object.setPrototypeOf(this, LegacyListCollectionsCursor.prototype);
+    }
+  });
+
+  return LegacyListCollectionsCursor;
+};
+
+module.exports.makeLegacyListIndexesCursor = function (baseClass) {
+  class LegacyListIndexesCursor extends baseClass {}
+
+  for (const [name, method] of commonCursorFunctions) {
+    Object.defineProperty(LegacyListIndexesCursor.prototype, name, {
+      enumerable: false,
+      value: method
+    });
+  }
+
+  Object.defineProperty(baseClass.prototype, toLegacy, {
+    enumerable: false,
+    value: function () {
+      return Object.setPrototypeOf(this, LegacyListIndexesCursor.prototype);
+    }
+  });
+
+  return LegacyListIndexesCursor;
+};
+
+module.exports.makeLegacyAggregationCursor = function (baseClass) {
+  class LegacyAggregationCursor extends baseClass {
+    explain(verbosity, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof verbosity === 'function'
+          ? verbosity
+          : undefined;
+      verbosity = typeof verbosity !== 'function' ? verbosity : undefined;
+      return maybeCallback(super.explain(verbosity), callback);
+    }
+  }
+
+  for (const [name, method] of commonCursorFunctions) {
+    Object.defineProperty(LegacyAggregationCursor.prototype, name, {
+      enumerable: false,
+      value: method
+    });
+  }
+
+  Object.defineProperty(baseClass.prototype, toLegacy, {
+    enumerable: false,
+    value: function () {
+      return Object.setPrototypeOf(this, LegacyAggregationCursor.prototype);
+    }
+  });
+
+  return LegacyAggregationCursor;
+};

--- a/src/legacy_wrappers/db.js
+++ b/src/legacy_wrappers/db.js
@@ -1,0 +1,190 @@
+'use strict';
+
+const { toLegacy, maybeCallback } = require('../utils');
+
+module.exports = Object.create(null);
+Object.defineProperty(module.exports, '__esModule', { value: true });
+
+module.exports.makeLegacyDb = function (baseClass) {
+  class LegacyDb extends baseClass {
+    command(command, options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.command(command, options), callback);
+    }
+
+    // Async APIs
+    addUser(username, password, options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : typeof password === 'function'
+          ? password
+          : undefined;
+      options =
+        typeof options !== 'function'
+          ? options
+          : typeof password !== 'function'
+          ? password
+          : undefined;
+      return maybeCallback(super.addUser(username, password, options), callback);
+    }
+
+    removeUser(username, options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.removeUser(username, options), callback);
+    }
+
+    createCollection(name, options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(
+        super.createCollection(name, options).then(collection => collection[toLegacy]()),
+        callback
+      );
+    }
+
+    dropCollection(name, options, callback) {
+      return maybeCallback(super.dropCollection(name, options), callback);
+    }
+
+    createIndex(name, indexSpec, options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.createIndex(name, indexSpec, options), callback);
+    }
+
+    dropDatabase(options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.dropDatabase(options), callback);
+    }
+
+    indexInformation(name, options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.indexInformation(name, options), callback);
+    }
+
+    profilingLevel(options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.profilingLevel(options), callback);
+    }
+
+    setProfilingLevel(level, options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.setProfilingLevel(level, options), callback);
+    }
+
+    renameCollection(from, to, options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(
+        super.renameCollection(from, to, options).then(collection => collection[toLegacy]()),
+        callback
+      );
+    }
+
+    stats(options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.stats(options), callback);
+    }
+
+    // Convert Result to legacy
+    collections(options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(
+        super
+          .collections(options)
+          .then(collections => collections.map(collection => collection[toLegacy]())),
+        callback
+      );
+    }
+    collection(name, options) {
+      return super.collection(name, options)[toLegacy]();
+    }
+    admin() {
+      return super.admin()[toLegacy]();
+    }
+    aggregate(pipeline, options) {
+      return super.aggregate(pipeline, options)[toLegacy]();
+    }
+    listCollections(filter, options) {
+      return super.listCollections(filter, options)[toLegacy]();
+    }
+    watch(pipeline, options) {
+      return super.watch(pipeline, options)[toLegacy]();
+    }
+  }
+
+  Object.defineProperty(baseClass.prototype, toLegacy, {
+    enumerable: false,
+    value: function () {
+      return Object.setPrototypeOf(this, LegacyDb.prototype);
+    }
+  });
+
+  return LegacyDb;
+};

--- a/src/legacy_wrappers/db.js
+++ b/src/legacy_wrappers/db.js
@@ -29,9 +29,9 @@ module.exports.makeLegacyDb = function (baseClass) {
           ? password
           : undefined;
       options =
-        typeof options !== 'function'
+        options != null && typeof options === 'object'
           ? options
-          : typeof password !== 'function'
+          : password != null && typeof password === 'object'
           ? password
           : undefined;
       return maybeCallback(super.addUser(username, password, options), callback);

--- a/src/legacy_wrappers/gridfs.js
+++ b/src/legacy_wrappers/gridfs.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const { toLegacy, maybeCallback } = require('../utils');
+
+module.exports = Object.create(null);
+Object.defineProperty(module.exports, '__esModule', { value: true });
+
+module.exports.makeLegacyGridFSBucket = function (baseClass) {
+  class LegacyGridFSBucket extends baseClass {
+    delete(id, callback) {
+      return maybeCallback(super.delete(id), callback);
+    }
+
+    rename(id, filename, callback) {
+      return maybeCallback(super.rename(id, filename), callback);
+    }
+
+    drop(callback) {
+      return maybeCallback(super.drop(), callback);
+    }
+
+    // conversion
+    find(filter, options) {
+      return super.find(filter, options)[toLegacy]();
+    }
+  }
+
+  Object.defineProperty(baseClass.prototype, toLegacy, {
+    enumerable: false,
+    value: function () {
+      return Object.setPrototypeOf(this, LegacyGridFSBucket.prototype);
+    }
+  });
+
+  return LegacyGridFSBucket;
+};
+
+module.exports.makeLegacyGridFSBucketWriteStream = function (baseClass) {
+  class LegacyGridFSBucketWriteStream extends baseClass {
+    abort(callback) {
+      maybeCallback(super.abort(), callback);
+    }
+  }
+
+  Object.defineProperty(baseClass.prototype, toLegacy, {
+    enumerable: false,
+    value: function () {
+      return Object.setPrototypeOf(this, LegacyGridFSBucketWriteStream.prototype);
+    }
+  });
+
+  return LegacyGridFSBucketWriteStream;
+};

--- a/src/legacy_wrappers/mongo_client.js
+++ b/src/legacy_wrappers/mongo_client.js
@@ -15,8 +15,12 @@ module.exports.makeLegacyMongoClient = function (baseClass) {
           ? options
           : undefined;
       options = typeof options !== 'function' ? options : undefined;
-      const client = new this(url, options);
-      return maybeCallback(client.connect(callback), callback);
+      try {
+        const client = new this(url, options);
+        return maybeCallback(client.connect(callback), callback);
+      } catch (error) {
+        return maybeCallback(() => Promise.reject(error), callback);
+      }
     }
 
     connect(callback) {

--- a/src/legacy_wrappers/mongo_client.js
+++ b/src/legacy_wrappers/mongo_client.js
@@ -15,15 +15,16 @@ module.exports.makeLegacyMongoClient = function (baseClass) {
           ? options
           : undefined;
       options = typeof options !== 'function' ? options : undefined;
+      const client = new this(url, options);
       return maybeCallback(
-        baseClass.connect(url, options).then(client => client[toLegacy]()),
+        client.connect(callback).then(() => client),
         callback
       );
     }
 
     connect(callback) {
       return maybeCallback(
-        super.connect().then(client => client[toLegacy]()),
+        super.connect().then(() => this),
         callback
       );
     }
@@ -59,13 +60,6 @@ module.exports.makeLegacyMongoClient = function (baseClass) {
       return super.withSession(options, session => executeWithSession(session[toLegacy]()));
     }
   }
-
-  Object.defineProperty(baseClass.prototype, toLegacy, {
-    enumerable: false,
-    value: function () {
-      return Object.setPrototypeOf(this, LegacyMongoClient.prototype);
-    }
-  });
 
   return LegacyMongoClient;
 };

--- a/src/legacy_wrappers/mongo_client.js
+++ b/src/legacy_wrappers/mongo_client.js
@@ -19,7 +19,7 @@ module.exports.makeLegacyMongoClient = function (baseClass) {
         const client = new this(url, options);
         return maybeCallback(client.connect(callback), callback);
       } catch (error) {
-        return maybeCallback(() => Promise.reject(error), callback);
+        return maybeCallback(Promise.reject(error), callback);
       }
     }
 

--- a/src/legacy_wrappers/mongo_client.js
+++ b/src/legacy_wrappers/mongo_client.js
@@ -16,10 +16,7 @@ module.exports.makeLegacyMongoClient = function (baseClass) {
           : undefined;
       options = typeof options !== 'function' ? options : undefined;
       const client = new this(url, options);
-      return maybeCallback(
-        client.connect(callback).then(() => client),
-        callback
-      );
+      return maybeCallback(client.connect(callback), callback);
     }
 
     connect(callback) {

--- a/src/legacy_wrappers/mongo_client.js
+++ b/src/legacy_wrappers/mongo_client.js
@@ -20,10 +20,7 @@ module.exports.makeLegacyMongoClient = function (baseClass) {
     }
 
     connect(callback) {
-      return maybeCallback(
-        super.connect().then(() => this),
-        callback
-      );
+      return maybeCallback(super.connect(), callback);
     }
 
     close(force, callback) {

--- a/src/legacy_wrappers/mongo_client.js
+++ b/src/legacy_wrappers/mongo_client.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const { toLegacy, maybeCallback } = require('../utils');
+
+module.exports = Object.create(null);
+Object.defineProperty(module.exports, '__esModule', { value: true });
+
+module.exports.makeLegacyMongoClient = function (baseClass) {
+  class LegacyMongoClient extends baseClass {
+    static connect(url, options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(
+        baseClass.connect(url, options).then(client => client[toLegacy]()),
+        callback
+      );
+    }
+
+    connect(callback) {
+      return maybeCallback(
+        super.connect().then(client => client[toLegacy]()),
+        callback
+      );
+    }
+
+    close(force, callback) {
+      callback =
+        typeof callback === 'function' ? callback : typeof force === 'function' ? force : undefined;
+      force = typeof force !== 'function' ? force : undefined;
+      return maybeCallback(super.close(force), callback);
+    }
+
+    // Convert to legacy versions of the following:
+    db(dbName, options) {
+      return super.db(dbName, options)[toLegacy]();
+    }
+
+    watch(pipeline, options) {
+      return super.watch(pipeline, options)[toLegacy]();
+    }
+
+    startSession(options) {
+      return super.startSession(options)[toLegacy]();
+    }
+
+    withSession(options, executeWithSession) {
+      executeWithSession =
+        typeof executeWithSession === 'function'
+          ? executeWithSession
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return super.withSession(options, session => executeWithSession(session[toLegacy]()));
+    }
+  }
+
+  Object.defineProperty(baseClass.prototype, toLegacy, {
+    enumerable: false,
+    value: function () {
+      return Object.setPrototypeOf(this, LegacyMongoClient.prototype);
+    }
+  });
+
+  return LegacyMongoClient;
+};

--- a/src/legacy_wrappers/session.js
+++ b/src/legacy_wrappers/session.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const { toLegacy, maybeCallback } = require('../utils');
+
+module.exports = Object.create(null);
+Object.defineProperty(module.exports, '__esModule', { value: true });
+
+module.exports.makeLegacyClientSession = function (baseClass) {
+  class LegacyClientSession extends baseClass {
+    abortTransaction(callback) {
+      return maybeCallback(super.abortTransaction(), callback);
+    }
+
+    commitTransaction(callback) {
+      return maybeCallback(super.commitTransaction(), callback);
+    }
+
+    endSession(options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+          ? options
+          : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.endSession(options), callback);
+    }
+
+    withTransaction(executeWithTransaction, options) {
+      super.withTransaction(session => executeWithTransaction(session[toLegacy]()), options);
+    }
+  }
+
+  Object.defineProperty(baseClass.prototype, toLegacy, {
+    enumerable: false,
+    value: function () {
+      return Object.setPrototypeOf(this, LegacyClientSession.prototype);
+    }
+  });
+
+  return LegacyClientSession;
+};

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,25 @@
+'use strict';
+
+module.exports = Object.create(null);
+Object.defineProperty(module.exports, '__esModule', { value: true });
+
+module.exports.toLegacy = Symbol.for('@@mdb.callbacks.toLegacy');
+
+/**
+ *
+ * @template T
+ * @param {Promise<T>} promise - promise intended for optional wrapping in callback style invocation
+ * @param {(error?: Error, result?: T) => void} [callback] - optional callback argument to handle in case the API was invoked with a callback
+ * @returns {Promise<T> | void}
+ */
+module.exports.maybeCallback = (promise, callback) => {
+  if (callback != null) {
+    promise.then(
+      result => callback(undefined, result),
+      error => callback(error)
+    );
+    return;
+  }
+
+  return promise;
+};

--- a/test/hooks/addons.js
+++ b/test/hooks/addons.js
@@ -1,0 +1,6 @@
+'use strict';
+
+const chai = require('chai');
+chai.use(require('sinon-chai'));
+
+module.exports = {};

--- a/test/tools/api.js
+++ b/test/tools/api.js
@@ -40,7 +40,7 @@ const asyncApi = [
   { className: 'AggregationCursor', method: 'explain', returnType: 'Promise<Document>' },
 
   // Super class of Unordered/Ordered Bulk operations
-  // This is listed here as a reference for completeness, but it is tested manually
+  // This is listed here as a reference for completeness, but it is tested by the subclass overrides of execute
   // { className: 'BulkOperationBase', method: 'execute', returnType: 'Promise<BulkWriteResult>' },
   { className: 'OrderedBulkOperation', method: 'execute', returnType: 'Promise<BulkWriteResult>' },
   { className: 'UnorderedBulkOperation', method: 'execute', returnType: 'Promise<BulkWriteResult>' },

--- a/test/tools/api.js
+++ b/test/tools/api.js
@@ -111,6 +111,8 @@ const asyncApi = [
 
   { className: 'MongoClient', method: 'close', returnType: 'Promise<void>' },
   { className: 'MongoClient', method: 'connect', returnType: 'Promise<this>' },
+  // Manually test the static version of connect
+  // { className: 'MongoClient', method: 'static connect', returnType: 'Promise<this>' },
 ];
 
 const transformMethods = [

--- a/test/tools/api.js
+++ b/test/tools/api.js
@@ -114,6 +114,8 @@ const asyncApi = [
   { className: 'MongoClient', method: 'connect', returnType: 'Promise<this>' },
   // Manually test the static version of connect
   // This is listed here as a reference for completeness, but it is tested manually
+  // it is checked to exist in index.test.js
+  // its functionally tested in maybe_callback.test.js
   // { className: 'MongoClient', method: 'static connect', returnType: 'Promise<this>' },
 ];
 

--- a/test/tools/api.js
+++ b/test/tools/api.js
@@ -40,6 +40,7 @@ const asyncApi = [
   { className: 'AggregationCursor', method: 'explain', returnType: 'Promise<Document>' },
 
   // Super class of Unordered/Ordered Bulk operations
+  // This is listed here as a reference for completeness, but it is tested manually
   // { className: 'BulkOperationBase', method: 'execute', returnType: 'Promise<BulkWriteResult>' },
   { className: 'OrderedBulkOperation', method: 'execute', returnType: 'Promise<BulkWriteResult>' },
   { className: 'UnorderedBulkOperation', method: 'execute', returnType: 'Promise<BulkWriteResult>' },
@@ -112,6 +113,7 @@ const asyncApi = [
   { className: 'MongoClient', method: 'close', returnType: 'Promise<void>' },
   { className: 'MongoClient', method: 'connect', returnType: 'Promise<this>' },
   // Manually test the static version of connect
+  // This is listed here as a reference for completeness, but it is tested manually
   // { className: 'MongoClient', method: 'static connect', returnType: 'Promise<this>' },
 ];
 

--- a/test/tools/api.js
+++ b/test/tools/api.js
@@ -146,6 +146,8 @@ const transformMethods = [
 module.exports.asyncApi = asyncApi;
 module.exports.transformMethods = transformMethods;
 module.exports.asyncApiClasses = new Set(asyncApi.map(({className}) => className))
-module.exports.classesToMethods = new Map([...asyncApi, ...transformMethods].map((api, _, array) =>
-  [api.className, new Set(array.filter(v => v.className === api.className))]
-));
+module.exports.classNameToMethodList = new Map([...asyncApi, ...transformMethods].map((api, _, array) => {
+  const methodNames = Array.from(new Set(Array.from(array.filter(v => v.className === api.className), ({ method }) => method)))
+  methodNames.sort((a, b) => a.localeCompare(b))
+  return [api.className, methodNames]
+}));

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -29,5 +29,9 @@ describe('index.js', () => {
         }
       });
     }
+
+    it('class MongoClient should define static override connect()', () => {
+      expect(mdbLegacy.MongoClient).to.have.own.property('connect').that.is.a('function');
+    });
   });
 });

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const { expect } = require('chai');
+const mdbLegacy = require('../..');
+const mdbDriver = require('mongodb');
+const { asyncApiClasses, classesToMethods } = require('../tools/api');
+
+describe('index.js', () => {
+  it('should export everything mongodb does', () => {
+    expect(mdbLegacy).to.have.all.keys(Object.keys(mdbDriver));
+  });
+
+  for (const className of asyncApiClasses) {
+    it(`should export ${className} as a subclass of mongodb.${className}`, () => {
+      expect(mdbLegacy[className]).to.have.property('prototype');
+      expect(mdbLegacy[className].prototype).to.be.instanceOf(mdbDriver[className]);
+    });
+  }
+
+  describe('subclass for legacy callback support', () => {
+    for (const [className, methods] of classesToMethods) {
+      describe(`class ${className}`, () => {
+        for (const { method } of methods) {
+          it(`should define override ${method}()`, () => {
+            expect(mdbLegacy[className].prototype)
+              .to.have.own.property(method)
+              .that.is.a('function');
+          });
+        }
+      });
+    }
+  });
+});

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -20,13 +20,24 @@ describe('index.js', () => {
   describe('subclass for legacy callback support', () => {
     for (const [className, methods] of classesToMethods) {
       describe(`class ${className}`, () => {
-        for (const { method } of methods) {
+        const methodNames = Array.from(new Set(Array.from(methods, ({ method }) => method)));
+        methodNames.sort((a, b) => String.prototype.localeCompare.call(a, b));
+
+        for (const method of methodNames) {
           it(`should define override ${method}()`, () => {
             expect(mdbLegacy[className].prototype)
               .to.have.own.property(method)
               .that.is.a('function');
           });
         }
+
+        it(`should only define methods declared in api table for ${className}`, () => {
+          let names = Object.getOwnPropertyNames(mdbLegacy[className].prototype).filter(
+            name => name !== 'constructor'
+          );
+          names.sort((a, b) => String.prototype.localeCompare.call(a, b));
+          expect(names).to.be.deep.equal(methodNames);
+        });
       });
     }
 

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -3,7 +3,7 @@
 const { expect } = require('chai');
 const mdbLegacy = require('../..');
 const mdbDriver = require('mongodb');
-const { asyncApiClasses, classesToMethods } = require('../tools/api');
+const { asyncApiClasses, classNameToMethodList } = require('../tools/api');
 
 describe('index.js', () => {
   it('should export everything mongodb does', () => {
@@ -18,11 +18,8 @@ describe('index.js', () => {
   }
 
   describe('subclass for legacy callback support', () => {
-    for (const [className, methods] of classesToMethods) {
+    for (const [className, methodNames] of classNameToMethodList) {
       describe(`class ${className}`, () => {
-        const methodNames = Array.from(new Set(Array.from(methods, ({ method }) => method)));
-        methodNames.sort((a, b) => String.prototype.localeCompare.call(a, b));
-
         for (const method of methodNames) {
           it(`should define override ${method}()`, () => {
             expect(mdbLegacy[className].prototype)

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -45,9 +45,25 @@ describe('utils.js', () => {
 
       it('should not modify a rejection error promise', async () => {
         class MyError extends Error {}
-        const rejection = Promise.reject(new MyError());
+        const driverError = Object.freeze(new MyError());
+        const rejection = Promise.reject(driverError);
         const thrownError = await maybeCallback(rejection, null).catch(error => error);
-        expect(thrownError).to.be.instanceOf(MyError);
+        expect(thrownError).to.be.equal(driverError);
+      });
+
+      it('should not modify a rejection error when passed to callback', done => {
+        class MyError extends Error {}
+        const driverError = Object.freeze(new MyError());
+        const rejection = Promise.reject(driverError);
+        maybeCallback(rejection, error => {
+          try {
+            expect(error).to.exist;
+            expect(error).to.equal(driverError);
+            done();
+          } catch (assertionError) {
+            done(assertionError);
+          }
+        });
       });
     });
 

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const { expect } = require('chai');
+const utils = require('../../src/utils');
+
+describe('utils.js', () => {
+  describe('exports', () => {
+    it('should have toLegacy symbol', () => {
+      expect(utils).to.have.property('toLegacy').that.is.a('symbol');
+    });
+
+    it('should have maybeCallback helper', () => {
+      expect(utils).to.have.property('maybeCallback').that.is.a('function');
+    });
+  });
+
+  describe('maybeCallback', () => {
+    const maybeCallback = utils.maybeCallback;
+    it('should accept to two arguments', () => {
+      expect(maybeCallback).to.have.lengthOf(2);
+    });
+
+    it('should return promise provided if no other arguments are present', async () => {
+      const promise = Promise.resolve(2);
+      const result = maybeCallback(promise);
+      expect(promise).to.equal(result);
+      expect(await result).to.equal(2);
+    });
+
+    it('should return void if callback is provided', () => {
+      const promise = Promise.resolve(2);
+      const result = maybeCallback(promise, () => null);
+      expect(result).to.be.undefined;
+    });
+
+    it('should call callback with the resolved value from the promise', done => {
+      const promise = Promise.resolve(2);
+      const result = maybeCallback(promise, (error, result) => {
+        try {
+          expect(error).to.not.exist;
+          expect(result).to.equal(2);
+          done();
+        } catch (assertionError) {
+          done(assertionError);
+        }
+      });
+      expect(result).to.be.undefined;
+    });
+
+    it('should not modify a rejection error promise', async () => {
+      class MyError extends Error {}
+      const rejection = Promise.reject(new MyError());
+      const thrownError = await maybeCallback(rejection, null).catch(error => error);
+      expect(thrownError).to.be.instanceOf(MyError);
+    });
+
+    it('should not modify a rejection error callback', done => {
+      class MyError extends Error {}
+      const rejection = Promise.reject(new MyError());
+      maybeCallback(rejection, (error, result) => {
+        try {
+          expect(result).to.not.exist;
+          expect(error).to.be.instanceOf(MyError);
+          return done();
+        } catch (assertionError) {
+          return done(assertionError);
+        }
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Description

#### What is changing?

Adds the legacy wrappers for our driver's async APIs.

#### What is the motivation for this change?

Backwards compat.

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
