### PR TITLE
chore(NODE-4568): add api-extractor script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "mongodb": "^4.9.0"
       },
       "devDependencies": {
+        "@microsoft/api-extractor-model": "^7.23.1",
         "@typescript-eslint/eslint-plugin": "^5.33.0",
         "@typescript-eslint/parser": "^5.33.0",
         "chai": "^4.3.6",
@@ -281,6 +282,48 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@microsoft/api-extractor-model": {
+      "version": "7.23.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.23.1.tgz",
+      "integrity": "sha512-axlZ33H2LfYX7goAaWpzABWZl3JtX/EUkfVBsI4SuMn3AZYBJsP5MVpMCq7jt0PCefWGwwO+Rv+lCmmJIjFhlQ==",
+      "dev": true,
+      "dependencies": {
+        "@microsoft/tsdoc": "0.14.1",
+        "@microsoft/tsdoc-config": "~0.16.1",
+        "@rushstack/node-core-library": "3.50.2"
+      }
+    },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.14.1.tgz",
+      "integrity": "sha512-6Wci+Tp3CgPt/B9B0a3J4s3yMgLNSku6w5TV6mN+61C71UqsRBv2FUibBf3tPGlNxebgPHMEUzKpb1ggE8KCKw==",
+      "dev": true
+    },
+    "node_modules/@microsoft/tsdoc-config": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.16.1.tgz",
+      "integrity": "sha512-2RqkwiD4uN6MLnHFljqBlZIXlt/SaUT6cuogU1w2ARw4nKuuppSmR0+s+NC+7kXBQykd9zzu0P4HtBpZT5zBpQ==",
+      "dev": true,
+      "dependencies": {
+        "@microsoft/tsdoc": "0.14.1",
+        "ajv": "~6.12.6",
+        "jju": "~1.4.0",
+        "resolve": "~1.19.0"
+      }
+    },
+    "node_modules/@microsoft/tsdoc-config/node_modules/resolve": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+      "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.1.0",
+        "path-parse": "^1.0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -314,6 +357,41 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@rushstack/node-core-library": {
+      "version": "3.50.2",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.50.2.tgz",
+      "integrity": "sha512-+zpZBcaX5s+wA0avF0Lk3sd5jbGRo5SmsEJpElJbqQd3KGFvc/hcyeNSMqV5+esJ1JuTfnE1QyRt8nvxFNTaQg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "12.20.24",
+        "colors": "~1.2.1",
+        "fs-extra": "~7.0.1",
+        "import-lazy": "~4.0.0",
+        "jju": "~1.4.0",
+        "resolve": "~1.17.0",
+        "semver": "~7.3.0",
+        "timsort": "~0.3.0",
+        "z-schema": "~5.0.2"
+      }
+    },
+    "node_modules/@rushstack/node-core-library/node_modules/@types/node": {
+      "version": "12.20.24",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.24.tgz",
+      "integrity": "sha512-yxDeaQIAJlMav7fH5AQqPH1u8YIuhYJXYBzxaQ4PifsU0GDO38MSdmEDeRlIxrKbC6NbEaaEHDanWb+y30U8SQ==",
+      "dev": true
+    },
+    "node_modules/@rushstack/node-core-library/node_modules/resolve": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+      "dev": true,
+      "dependencies": {
+        "path-parse": "^1.0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -644,7 +722,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1006,6 +1083,22 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "node_modules/colors": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.5.tgz",
+      "integrity": "sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/compare-func": {
       "version": "2.0.0",
@@ -1918,8 +2011,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/fast-diff": {
       "version": "1.2.0",
@@ -1947,8 +2039,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -2060,6 +2151,20 @@
       "integrity": "sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -2461,6 +2566,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/import-lazy": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
+      "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -2631,6 +2745,12 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/jju": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
+      "dev": true
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -2665,8 +2785,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -2680,6 +2799,15 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "dev": true
+    },
+    "node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
     },
     "node_modules/jsonparse": {
       "version": "1.3.1",
@@ -2790,6 +2918,12 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "dev": true
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
       "dev": true
     },
     "node_modules/lodash.ismatch": {
@@ -4279,6 +4413,12 @@
         "readable-stream": "3"
       }
     },
+    "node_modules/timsort": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
+      "integrity": "sha512-qsdtZH+vMoCARQtyod4imc2nIJwg9Cc7lPRrw9CzF8ZKR0khdr8+2nX80PBhET3tcyTtJDxAffGh2rXH4tyU8A==",
+      "dev": true
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -4451,12 +4591,20 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -4488,6 +4636,15 @@
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/webidl-conversions": {
@@ -4656,6 +4813,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/z-schema": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.3.tgz",
+      "integrity": "sha512-sGvEcBOTNum68x9jCpCVGPFJ6mWnkD0YxOcddDlJHRx3tKdB2q8pCHExMVZo/AV/6geuVJXG7hljDaWG8+5GDw==",
+      "dev": true,
+      "dependencies": {
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.5.0",
+        "validator": "^13.7.0"
+      },
+      "bin": {
+        "z-schema": "bin/z-schema"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "commander": "^2.20.3"
       }
     }
   },
@@ -4871,6 +5048,47 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "@microsoft/api-extractor-model": {
+      "version": "7.23.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.23.1.tgz",
+      "integrity": "sha512-axlZ33H2LfYX7goAaWpzABWZl3JtX/EUkfVBsI4SuMn3AZYBJsP5MVpMCq7jt0PCefWGwwO+Rv+lCmmJIjFhlQ==",
+      "dev": true,
+      "requires": {
+        "@microsoft/tsdoc": "0.14.1",
+        "@microsoft/tsdoc-config": "~0.16.1",
+        "@rushstack/node-core-library": "3.50.2"
+      }
+    },
+    "@microsoft/tsdoc": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.14.1.tgz",
+      "integrity": "sha512-6Wci+Tp3CgPt/B9B0a3J4s3yMgLNSku6w5TV6mN+61C71UqsRBv2FUibBf3tPGlNxebgPHMEUzKpb1ggE8KCKw==",
+      "dev": true
+    },
+    "@microsoft/tsdoc-config": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.16.1.tgz",
+      "integrity": "sha512-2RqkwiD4uN6MLnHFljqBlZIXlt/SaUT6cuogU1w2ARw4nKuuppSmR0+s+NC+7kXBQykd9zzu0P4HtBpZT5zBpQ==",
+      "dev": true,
+      "requires": {
+        "@microsoft/tsdoc": "0.14.1",
+        "ajv": "~6.12.6",
+        "jju": "~1.4.0",
+        "resolve": "~1.19.0"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.19.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+          "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+          "dev": true,
+          "requires": {
+            "is-core-module": "^2.1.0",
+            "path-parse": "^1.0.6"
+          }
+        }
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -4895,6 +5113,40 @@
       "requires": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
+      }
+    },
+    "@rushstack/node-core-library": {
+      "version": "3.50.2",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.50.2.tgz",
+      "integrity": "sha512-+zpZBcaX5s+wA0avF0Lk3sd5jbGRo5SmsEJpElJbqQd3KGFvc/hcyeNSMqV5+esJ1JuTfnE1QyRt8nvxFNTaQg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "12.20.24",
+        "colors": "~1.2.1",
+        "fs-extra": "~7.0.1",
+        "import-lazy": "~4.0.0",
+        "jju": "~1.4.0",
+        "resolve": "~1.17.0",
+        "semver": "~7.3.0",
+        "timsort": "~0.3.0",
+        "z-schema": "~5.0.2"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "12.20.24",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.24.tgz",
+          "integrity": "sha512-yxDeaQIAJlMav7fH5AQqPH1u8YIuhYJXYBzxaQ4PifsU0GDO38MSdmEDeRlIxrKbC6NbEaaEHDanWb+y30U8SQ==",
+          "dev": true
+        },
+        "resolve": {
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        }
       }
     },
     "@sinonjs/commons": {
@@ -5125,7 +5377,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
-      "peer": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5379,6 +5630,19 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "colors": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.5.tgz",
+      "integrity": "sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "optional": true
     },
     "compare-func": {
       "version": "2.0.0",
@@ -6075,8 +6339,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "fast-diff": {
       "version": "1.2.0",
@@ -6101,8 +6364,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -6189,6 +6451,17 @@
       "integrity": "sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==",
       "dev": true,
       "peer": true
+    },
+    "fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -6489,6 +6762,12 @@
         "resolve-from": "^4.0.0"
       }
     },
+    "import-lazy": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
+      "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
+      "dev": true
+    },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -6620,6 +6899,12 @@
       "dev": true,
       "peer": true
     },
+    "jju": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
+      "dev": true
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -6651,8 +6936,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -6666,6 +6950,15 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "dev": true
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
     },
     "jsonparse": {
       "version": "1.3.1",
@@ -6751,6 +7044,12 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "dev": true
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
       "dev": true
     },
     "lodash.ismatch": {
@@ -7860,6 +8159,12 @@
         "readable-stream": "3"
       }
     },
+    "timsort": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
+      "integrity": "sha512-qsdtZH+vMoCARQtyod4imc2nIJwg9Cc7lPRrw9CzF8ZKR0khdr8+2nX80PBhET3tcyTtJDxAffGh2rXH4tyU8A==",
+      "dev": true
+    },
     "to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -7969,12 +8274,17 @@
       "dev": true,
       "optional": true
     },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true
+    },
     "uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -8007,6 +8317,12 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "validator": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
+      "dev": true
     },
     "webidl-conversions": {
       "version": "7.0.0",
@@ -8130,6 +8446,18 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
+    },
+    "z-schema": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.3.tgz",
+      "integrity": "sha512-sGvEcBOTNum68x9jCpCVGPFJ6mWnkD0YxOcddDlJHRx3tKdB2q8pCHExMVZo/AV/6geuVJXG7hljDaWG8+5GDw==",
+      "dev": true,
+      "requires": {
+        "commander": "^2.20.3",
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.5.0",
+        "validator": "^13.7.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
+    "@microsoft/api-extractor-model": "^7.23.1",
     "@typescript-eslint/eslint-plugin": "^5.33.0",
     "@typescript-eslint/parser": "^5.33.0",
     "chai": "^4.3.6",

--- a/test/tools/api.js
+++ b/test/tools/api.js
@@ -1,0 +1,149 @@
+/* eslint-disable prettier/prettier */
+'use strict';
+
+module.exports = Object.create(null);
+Object.defineProperty(module.exports, '__esModule', { value: true });
+
+const commonCursorApis = [
+  { className: 'AbstractCursor', method: 'close', returnType: 'Promise<void>' },
+  { className: 'AbstractCursor', method: 'forEach', returnType: 'Promise<void>' },
+  { className: 'AbstractCursor', method: 'hasNext', returnType: 'Promise<boolean>' },
+  { className: 'AbstractCursor', method: 'next', returnType: 'Promise<TSchema | null>' },
+  { className: 'AbstractCursor', method: 'toArray', returnType: 'Promise<TSchema[]>' },
+  { className: 'AbstractCursor', method: 'tryNext', returnType: 'Promise<TSchema | null>' },
+]
+module.exports.commonCursorApis = commonCursorApis;
+
+const cursorClasses = [
+  'FindCursor',
+  'AggregationCursor',
+  'ListIndexesCursor',
+  'ListCollectionsCursor'
+]
+module.exports.cursorClasses = cursorClasses;
+
+const asyncApi = [
+  // Super class of cursors, we do not directly override these but override them in the inherited classes
+  ...commonCursorApis.flatMap(({ method, returnType }) => cursorClasses.map(cursorClass => ({ className: cursorClass, method, returnType }))),
+
+  { className: 'Admin', method: 'addUser', returnType: 'Promise<Document>' },
+  { className: 'Admin', method: 'buildInfo', returnType: 'Promise<Document>' },
+  { className: 'Admin', method: 'command', returnType: 'Promise<Document>' },
+  { className: 'Admin', method: 'listDatabases', returnType: 'Promise<ListDatabasesResult>' },
+  { className: 'Admin', method: 'ping', returnType: 'Promise<Document>' },
+  { className: 'Admin', method: 'removeUser', returnType: 'Promise<boolean>' },
+  { className: 'Admin', method: 'replSetGetStatus', returnType: 'Promise<Document>' },
+  { className: 'Admin', method: 'serverInfo', returnType: 'Promise<Document>' },
+  { className: 'Admin', method: 'serverStatus', returnType: 'Promise<Document>' },
+  { className: 'Admin', method: 'validateCollection', returnType: 'Promise<Document>' },
+
+  { className: 'AggregationCursor', method: 'explain', returnType: 'Promise<Document>' },
+
+  // Super class of Unordered/Ordered Bulk operations
+  // { className: 'BulkOperationBase', method: 'execute', returnType: 'Promise<BulkWriteResult>' },
+  { className: 'OrderedBulkOperation', method: 'execute', returnType: 'Promise<BulkWriteResult>' },
+  { className: 'UnorderedBulkOperation', method: 'execute', returnType: 'Promise<BulkWriteResult>' },
+
+  { className: 'ChangeStream', method: 'close', returnType: 'Promise<void>' },
+  { className: 'ChangeStream', method: 'hasNext', returnType: 'Promise<boolean>' },
+  { className: 'ChangeStream', method: 'next', returnType: 'Promise<TChange>' },
+  { className: 'ChangeStream', method: 'tryNext', returnType: 'Promise<Document | null>' },
+
+  { className: 'ClientSession', method: 'abortTransaction', returnType: 'Promise<Document>' },
+  { className: 'ClientSession', method: 'commitTransaction', returnType: 'Promise<Document>' },
+  { className: 'ClientSession', method: 'endSession', returnType: 'Promise<void>' },
+
+  { className: 'Collection', method: 'bulkWrite', returnType: 'Promise<BulkWriteResult>' },
+  { className: 'Collection', method: 'count', returnType: 'Promise<number>' },
+  { className: 'Collection', method: 'countDocuments', returnType: 'Promise<number>' },
+  { className: 'Collection', method: 'createIndex', returnType: 'Promise<string>' },
+  { className: 'Collection', method: 'createIndexes', returnType: 'Promise<string[]>' },
+  { className: 'Collection', method: 'deleteMany', returnType: 'Promise<DeleteResult>' },
+  { className: 'Collection', method: 'deleteOne', returnType: 'Promise<DeleteResult>' },
+  { className: 'Collection', method: 'distinct', returnType: 'Promise<Array<Flatten<WithId<TSchema>[Key]>>>' },
+  { className: 'Collection', method: 'drop', returnType: 'Promise<boolean>' },
+  { className: 'Collection', method: 'dropIndex', returnType: 'Promise<Document>' },
+  { className: 'Collection', method: 'dropIndexes', returnType: 'Promise<Document>' },
+  { className: 'Collection', method: 'estimatedDocumentCount', returnType: 'Promise<number>' },
+  { className: 'Collection', method: 'findOne', returnType: 'Promise<WithId<TSchema> | null>' },
+  { className: 'Collection', method: 'findOneAndDelete', returnType: 'Promise<ModifyResult<TSchema>>' },
+  { className: 'Collection', method: 'findOneAndReplace', returnType: 'Promise<ModifyResult<TSchema>>' },
+  { className: 'Collection', method: 'findOneAndUpdate', returnType: 'Promise<ModifyResult<TSchema>>' },
+  { className: 'Collection', method: 'indexes', returnType: 'Promise<Document[]>' },
+  { className: 'Collection', method: 'indexExists', returnType: 'Promise<boolean>' },
+  { className: 'Collection', method: 'indexInformation', returnType: 'Promise<Document>' },
+  { className: 'Collection', method: 'insert', returnType: 'Promise<InsertManyResult<TSchema>> | void' },
+  { className: 'Collection', method: 'insertMany', returnType: 'Promise<InsertManyResult<TSchema>>' },
+  { className: 'Collection', method: 'insertOne', returnType: 'Promise<InsertOneResult<TSchema>>' },
+  { className: 'Collection', method: 'isCapped', returnType: 'Promise<boolean>' },
+  { className: 'Collection', method: 'mapReduce', returnType: 'Promise<Document | Document[]>' },
+  { className: 'Collection', method: 'options', returnType: 'Promise<Document>' },
+  { className: 'Collection', method: 'remove', returnType: 'Promise<DeleteResult> | void' },
+  { className: 'Collection', method: 'rename', returnType: 'Promise<Collection>' },
+  { className: 'Collection', method: 'replaceOne', returnType: 'Promise<UpdateResult | Document>' },
+  { className: 'Collection', method: 'stats', returnType: 'Promise<CollStats>' },
+  { className: 'Collection', method: 'update', returnType: 'Promise<UpdateResult> | void' },
+  { className: 'Collection', method: 'updateMany', returnType: 'Promise<UpdateResult | Document>' },
+  { className: 'Collection', method: 'updateOne', returnType: 'Promise<UpdateResult>' },
+
+  { className: 'Db', method: 'addUser', returnType: 'Promise<Document>' },
+  { className: 'Db', method: 'collections', returnType: 'Promise<Collection[]>' },
+  { className: 'Db', method: 'command', returnType: 'Promise<Document>' },
+  { className: 'Db', method: 'createCollection', returnType: 'Promise<Collection<TSchema>>' },
+  { className: 'Db', method: 'createIndex', returnType: 'Promise<string>' },
+  { className: 'Db', method: 'dropCollection', returnType: 'Promise<boolean>' },
+  { className: 'Db', method: 'dropDatabase', returnType: 'Promise<boolean>' },
+  { className: 'Db', method: 'indexInformation', returnType: 'Promise<Document>' },
+  { className: 'Db', method: 'profilingLevel', returnType: 'Promise<string>' },
+  { className: 'Db', method: 'removeUser', returnType: 'Promise<boolean>' },
+  { className: 'Db', method: 'renameCollection', returnType: 'Promise<Collection<TSchema>>' },
+  { className: 'Db', method: 'setProfilingLevel', returnType: 'Promise<ProfilingLevel>' },
+  { className: 'Db', method: 'stats', returnType: 'Promise<Document>' },
+
+  { className: 'FindCursor', method: 'count', returnType: 'Promise<number>' },
+  { className: 'FindCursor', method: 'explain', returnType: 'Promise<Document>' },
+
+  { className: 'GridFSBucket', method: 'delete', returnType: 'Promise<void>' },
+  { className: 'GridFSBucket', method: 'drop', returnType: 'Promise<void>' },
+  { className: 'GridFSBucket', method: 'rename', returnType: 'Promise<void>' },
+
+  { className: 'GridFSBucketWriteStream', method: 'abort', returnType: 'Promise<void>' },
+
+  { className: 'MongoClient', method: 'close', returnType: 'Promise<void>' },
+  { className: 'MongoClient', method: 'connect', returnType: 'Promise<this>' },
+];
+
+const transformMethods = [
+  { className: 'MongoClient', method: 'startSession', returnType: 'ClientSession' },
+  { className: 'MongoClient', method: 'db', returnType: 'Db' },
+  { className: 'MongoClient', method: 'watch', returnType: 'ChangeStream' },
+  // Special case, calls toLegacy before executor callback
+  { className: 'MongoClient', method: 'withSession', returnType: 'Promise<void>' },
+
+  { className: 'Db', method: 'collection', returnType: 'Collection' },
+  { className: 'Db', method: 'admin', returnType: 'Admin' },
+  { className: 'Db', method: 'aggregate', returnType: 'AggregationCursor' },
+  { className: 'Db', method: 'listCollections', returnType: 'ListCollectionsCursor' },
+  { className: 'Db', method: 'watch', returnType: 'ChangeStream' },
+  { className: 'Db', method: 'collections', returnType: 'Promise<Collection[]>' },
+  { className: 'Db', method: 'renameCollection', returnType: 'Promise<Collection>' },
+  { className: 'Db', method: 'createCollection', returnType: 'Promise<Collection>' },
+
+  { className: 'Collection', method: 'aggregate', returnType: 'AggregationCursor' },
+  { className: 'Collection', method: 'find', returnType: 'FindCursor' },
+  { className: 'Collection', method: 'listIndexes', returnType: 'ListIndexesCursor' },
+  { className: 'Collection', method: 'watch', returnType: 'ChangeStream' },
+
+  { className: 'GridFSBucket', method: 'find', returnType: 'FindCursor' },
+
+  // Special case, calls toLegacy before executor callback
+  { className: 'ClientSession', method: 'withTransaction', returnType: 'Promise<void>' },
+
+];
+
+module.exports.asyncApi = asyncApi;
+module.exports.transformMethods = transformMethods;
+module.exports.asyncApiClasses = new Set(asyncApi.map(({className}) => className))
+module.exports.classesToMethods = new Map([...asyncApi, ...transformMethods].map((api, _, array) =>
+  [api.className, new Set(array.filter(v => v.className === api.className))]
+));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "ts-node": {
+        "transpileOnly": true,
+    },
+}


### PR DESCRIPTION
Uses api model library to simplify logic for finding async methods.
Constructs a file (`api.js`) that is intended to be curated by hand only after this PR which will be used to confirm coverage and construct table tests in mocha.