### PR TITLE
feat(NODE-4559): add mongodb-legacy metadata

### DIFF
--- a/src/legacy_wrappers/mongo_client.js
+++ b/src/legacy_wrappers/mongo_client.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { toLegacy, maybeCallback } = require('../utils');
+const { toLegacy, maybeCallback, addLegacyMetadata } = require('../utils');
 
 module.exports = Object.create(null);
 Object.defineProperty(module.exports, '__esModule', { value: true });
@@ -10,11 +10,7 @@ module.exports.makeLegacyMongoClient = function (baseClass) {
     // constructor adds client metadata before constructing final client
     constructor(connectionString, options) {
       options = { ...options };
-      if (options.driverInfo != null && typeof options.driverInfo.name === 'string') {
-        options.driverInfo.name += '|mongodb-legacy';
-      } else {
-        options.driverInfo = { name: 'mongodb-legacy' };
-      }
+      addLegacyMetadata(options);
 
       super(connectionString, options);
     }

--- a/src/legacy_wrappers/mongo_client.js
+++ b/src/legacy_wrappers/mongo_client.js
@@ -9,7 +9,9 @@ module.exports.makeLegacyMongoClient = function (baseClass) {
   class LegacyMongoClient extends baseClass {
     // constructor adds client metadata before constructing final client
     constructor(connectionString, options) {
-      options = { ...options };
+      if (options == null) {
+        options = {};
+      }
       addLegacyMetadata(options);
 
       super(connectionString, options);

--- a/src/legacy_wrappers/mongo_client.js
+++ b/src/legacy_wrappers/mongo_client.js
@@ -7,6 +7,18 @@ Object.defineProperty(module.exports, '__esModule', { value: true });
 
 module.exports.makeLegacyMongoClient = function (baseClass) {
   class LegacyMongoClient extends baseClass {
+    // constructor adds client metadata before constructing final client
+    constructor(connectionString, options) {
+      options = { ...options };
+      if (options.driverInfo != null && typeof options.driverInfo.name === 'string') {
+        options.driverInfo.name += '|mongodb-legacy';
+      } else {
+        options.driverInfo = { name: 'mongodb-legacy' };
+      }
+
+      super(connectionString, options);
+    }
+
     static connect(url, options, callback) {
       callback =
         typeof callback === 'function'

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { version } = require('../package.json');
+
 module.exports = Object.create(null);
 Object.defineProperty(module.exports, '__esModule', { value: true });
 
@@ -22,4 +24,24 @@ module.exports.maybeCallback = (promise, callback) => {
   }
 
   return promise;
+};
+
+module.exports.addLegacyMetadata = options => {
+  if (options.driverInfo == null) {
+    options.driverInfo = {
+      name: 'mongodb-legacy',
+      version
+    };
+  } else {
+    if (typeof options.driverInfo.name === 'string') {
+      options.driverInfo.name = `mongodb-legacy|${options.driverInfo.name}`;
+    } else {
+      options.driverInfo.name = 'mongodb-legacy';
+    }
+    if (typeof options.driverInfo.version === 'string') {
+      options.driverInfo.version = `${version}|${options.driverInfo.version}`;
+    } else {
+      options.driverInfo.version = version;
+    }
+  }
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const { version } = require('../package.json');
-
 module.exports = Object.create(null);
 Object.defineProperty(module.exports, '__esModule', { value: true });
 
@@ -24,32 +22,4 @@ module.exports.maybeCallback = (promise, callback) => {
   }
 
   return promise;
-};
-
-module.exports.addLegacyMetadata = options => {
-  const incorrectOptionsType = typeof options !== 'object';
-  const incorrectDriverInfo = options.driverInfo != null && typeof options.driverInfo !== 'object';
-  if (incorrectOptionsType || incorrectDriverInfo) {
-    // Pass this mistake along to the MongoClient constructor
-    return;
-  }
-
-  options.driverInfo = options.driverInfo == null ? {} : options.driverInfo;
-
-  const infoParts = {
-    name: ['mongodb-legacy'],
-    version: [version]
-  };
-
-  // name handling
-  if (typeof options.driverInfo.name === 'string') {
-    infoParts.name.push(options.driverInfo.name);
-  }
-  options.driverInfo.name = infoParts.name.join('|');
-
-  // version handling
-  if (typeof options.driverInfo.version === 'string') {
-    infoParts.version.push(options.driverInfo.version);
-  }
-  options.driverInfo.version = infoParts.version.join('|');
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -27,21 +27,26 @@ module.exports.maybeCallback = (promise, callback) => {
 };
 
 module.exports.addLegacyMetadata = options => {
-  if (options.driverInfo == null) {
-    options.driverInfo = {
-      name: 'mongodb-legacy',
-      version
-    };
-  } else {
-    if (typeof options.driverInfo.name === 'string') {
-      options.driverInfo.name = `mongodb-legacy|${options.driverInfo.name}`;
-    } else {
-      options.driverInfo.name = 'mongodb-legacy';
-    }
-    if (typeof options.driverInfo.version === 'string') {
-      options.driverInfo.version = `${version}|${options.driverInfo.version}`;
-    } else {
-      options.driverInfo.version = version;
-    }
+  if (options.driverInfo != null && typeof options.driverInfo !== 'object') {
+    return;
   }
+
+  options.driverInfo = options.driverInfo == null ? {} : options.driverInfo;
+
+  const infoParts = {
+    name: ['mongodb-legacy'],
+    version: [version]
+  };
+
+  // name handling
+  if (typeof options.driverInfo.name === 'string') {
+    infoParts.name.push(options.driverInfo.name);
+  }
+  options.driverInfo.name = infoParts.name.join('|');
+
+  // version handling
+  if (typeof options.driverInfo.version === 'string') {
+    infoParts.version.push(options.driverInfo.version);
+  }
+  options.driverInfo.version = infoParts.version.join('|');
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -27,7 +27,10 @@ module.exports.maybeCallback = (promise, callback) => {
 };
 
 module.exports.addLegacyMetadata = options => {
-  if (options.driverInfo != null && typeof options.driverInfo !== 'object') {
+  const incorrectOptionsType = typeof options !== 'object';
+  const incorrectDriverInfo = options.driverInfo != null && typeof options.driverInfo !== 'object';
+  if (incorrectOptionsType || incorrectDriverInfo) {
+    // Pass this mistake along to the MongoClient constructor
     return;
   }
 

--- a/test/unit/legacy_wrappers/mongo_client.test.js
+++ b/test/unit/legacy_wrappers/mongo_client.test.js
@@ -24,51 +24,55 @@ describe('legacy_wrappers/mongo_client.js', () => {
     await client.close();
   });
 
-  describe('client metadata', () => {
-    it('should set mongodb-legacy to the client metadata', () => {
-      const client = new LegacyMongoClient(iLoveJs);
-      expect(client.options.metadata).to.have.nested.property(
-        'driver.name',
-        'nodejs|mongodb-legacy'
-      );
-      expect(client.options.metadata)
-        .to.have.property('version')
-        .that.includes(currentLegacyVersion);
-    });
-
-    it('should prepend mongodb-legacy to existing driverInfo.name', () => {
-      const client = new LegacyMongoClient(iLoveJs, { driverInfo: { name: 'mongoose' } });
-      expect(client.options.metadata).to.have.nested.property(
-        'driver.name',
-        'nodejs|mongodb-legacy|mongoose'
-      );
-      expect(client.options.metadata)
-        .to.have.property('version')
-        .that.includes(currentLegacyVersion);
-    });
-
-    it('should prepend mongodb-legacy to existing driverInfo.name and legacy version number', () => {
-      const client = new LegacyMongoClient(iLoveJs, {
-        driverInfo: { name: 'mongoose', version: '99.99.99' }
+  describe('setting client metadata', () => {
+    describe('when no driverInfo is passed to MongoClient()', () => {
+      it('should set mongodb-legacy to the client metadata', () => {
+        const client = new LegacyMongoClient(iLoveJs);
+        expect(client.options.metadata).to.have.nested.property(
+          'driver.name',
+          'nodejs|mongodb-legacy'
+        );
+        expect(client.options.metadata)
+          .to.have.property('version')
+          .that.includes(currentLegacyVersion);
       });
-      expect(client.options.metadata)
-        .to.have.nested.property('driver.name')
-        .that.equals('nodejs|mongodb-legacy|mongoose');
-      expect(client.options.metadata)
-        .to.have.property('version')
-        .that.includes(`${currentLegacyVersion}|99.99.99`);
     });
 
-    it('should prepend legacy version number', () => {
-      const client = new LegacyMongoClient(iLoveJs, {
-        driverInfo: { version: '99.99.99' }
+    describe('when driverInfo is passed to MongoClient()', () => {
+      it('should prepend mongodb-legacy to user passed driverInfo.name', () => {
+        const client = new LegacyMongoClient(iLoveJs, { driverInfo: { name: 'mongoose' } });
+        expect(client.options.metadata).to.have.nested.property(
+          'driver.name',
+          'nodejs|mongodb-legacy|mongoose'
+        );
+        expect(client.options.metadata)
+          .to.have.property('version')
+          .that.includes(currentLegacyVersion);
       });
-      expect(client.options.metadata)
-        .to.have.nested.property('driver.name')
-        .that.equals('nodejs|mongodb-legacy');
-      expect(client.options.metadata)
-        .to.have.property('version')
-        .that.includes(`${currentLegacyVersion}|99.99.99`);
+
+      it('should prepend mongodb-legacy to user passed driverInfo.name and legacy version number to user passed driverInfo.version', () => {
+        const client = new LegacyMongoClient(iLoveJs, {
+          driverInfo: { name: 'mongoose', version: '99.99.99' }
+        });
+        expect(client.options.metadata)
+          .to.have.nested.property('driver.name')
+          .that.equals('nodejs|mongodb-legacy|mongoose');
+        expect(client.options.metadata)
+          .to.have.property('version')
+          .that.includes(`${currentLegacyVersion}|99.99.99`);
+      });
+
+      it('should prepend legacy version number to user passed driverInfo.version', () => {
+        const client = new LegacyMongoClient(iLoveJs, {
+          driverInfo: { version: '99.99.99' }
+        });
+        expect(client.options.metadata)
+          .to.have.nested.property('driver.name')
+          .that.equals('nodejs|mongodb-legacy');
+        expect(client.options.metadata)
+          .to.have.property('version')
+          .that.includes(`${currentLegacyVersion}|99.99.99`);
+      });
     });
   });
 

--- a/test/unit/legacy_wrappers/mongo_client.test.js
+++ b/test/unit/legacy_wrappers/mongo_client.test.js
@@ -25,7 +25,10 @@ describe('legacy_wrappers/mongo_client.js', () => {
   });
 
   describe('calling the constructor with invalid types', () => {
-    it('passing boolean to the options', () => {
+    it('should not throw when passing a non-object type as the options', () => {
+      // The driver ignores non-object types in the options arg position
+      // so this confirms our logic for adding metadata or any other handling
+      // does not introduce an error for non-object types
       expect(() => {
         new LegacyMongoClient(iLoveJs, true);
       }).to.not.throw();

--- a/test/unit/legacy_wrappers/mongo_client.test.js
+++ b/test/unit/legacy_wrappers/mongo_client.test.js
@@ -25,7 +25,7 @@ describe('legacy_wrappers/mongo_client.js', () => {
   });
 
   describe('setting client metadata', () => {
-    describe('when driverInto.name is provided', () => {
+    describe('when driverInfo.name is provided', () => {
       const client = new LegacyMongoClient(iLoveJs, { driverInfo: { name: 'mongoose' } });
 
       it('should prepend mongodb-legacy to user passed driverInfo.name', () =>
@@ -40,7 +40,7 @@ describe('legacy_wrappers/mongo_client.js', () => {
           .that.includes(currentLegacyVersion));
     });
 
-    describe('when driverInto.name is provided and driverInfo.version is provided', () => {
+    describe('when driverInfo.name is provided and driverInfo.version is provided', () => {
       const client = new LegacyMongoClient(iLoveJs, {
         driverInfo: { name: 'mongoose', version: '99.99.99' }
       });

--- a/test/unit/legacy_wrappers/mongo_client.test.js
+++ b/test/unit/legacy_wrappers/mongo_client.test.js
@@ -24,6 +24,14 @@ describe('legacy_wrappers/mongo_client.js', () => {
     await client.close();
   });
 
+  describe('calling the constructor with invalid types', () => {
+    it('passing boolean to the options', () => {
+      expect(() => {
+        new LegacyMongoClient(iLoveJs, true);
+      }).to.not.throw();
+    });
+  });
+
   describe('setting client metadata', () => {
     describe('when driverInfo.name is provided', () => {
       const client = new LegacyMongoClient(iLoveJs, { driverInfo: { name: 'mongoose' } });

--- a/test/unit/legacy_wrappers/mongo_client.test.js
+++ b/test/unit/legacy_wrappers/mongo_client.test.js
@@ -25,54 +25,65 @@ describe('legacy_wrappers/mongo_client.js', () => {
   });
 
   describe('setting client metadata', () => {
-    describe('when no driverInfo is passed to MongoClient()', () => {
-      it('should set mongodb-legacy to the client metadata', () => {
-        const client = new LegacyMongoClient(iLoveJs);
-        expect(client.options.metadata).to.have.nested.property(
-          'driver.name',
-          'nodejs|mongodb-legacy'
-        );
-        expect(client.options.metadata)
-          .to.have.property('version')
-          .that.includes(currentLegacyVersion);
-      });
-    });
+    describe('when driverInto.name is provided', () => {
+      const client = new LegacyMongoClient(iLoveJs, { driverInfo: { name: 'mongoose' } });
 
-    describe('when driverInfo is passed to MongoClient()', () => {
-      it('should prepend mongodb-legacy to user passed driverInfo.name', () => {
-        const client = new LegacyMongoClient(iLoveJs, { driverInfo: { name: 'mongoose' } });
+      it('should prepend mongodb-legacy to user passed driverInfo.name', () =>
         expect(client.options.metadata).to.have.nested.property(
           'driver.name',
           'nodejs|mongodb-legacy|mongoose'
-        );
+        ));
+
+      it('should include version in package.json to metadata version', () =>
         expect(client.options.metadata)
           .to.have.property('version')
-          .that.includes(currentLegacyVersion);
+          .that.includes(currentLegacyVersion));
+    });
+
+    describe('when driverInto.name is provided and driverInfo.version is provided', () => {
+      const client = new LegacyMongoClient(iLoveJs, {
+        driverInfo: { name: 'mongoose', version: '99.99.99' }
       });
 
-      it('should prepend mongodb-legacy to user passed driverInfo.name and legacy version number to user passed driverInfo.version', () => {
-        const client = new LegacyMongoClient(iLoveJs, {
-          driverInfo: { name: 'mongoose', version: '99.99.99' }
-        });
+      it('should prepend mongodb-legacy to user passed driverInfo.name', () =>
         expect(client.options.metadata)
           .to.have.nested.property('driver.name')
-          .that.equals('nodejs|mongodb-legacy|mongoose');
+          .that.equals('nodejs|mongodb-legacy|mongoose'));
+
+      it('should prepend version in package.json to user driverInfo.version', () =>
         expect(client.options.metadata)
           .to.have.property('version')
-          .that.includes(`${currentLegacyVersion}|99.99.99`);
+          .that.includes(`${currentLegacyVersion}|99.99.99`));
+    });
+
+    describe('when driverInfo.version is provided', () => {
+      const client = new LegacyMongoClient(iLoveJs, {
+        driverInfo: { version: '99.99.99' }
       });
 
-      it('should prepend legacy version number to user passed driverInfo.version', () => {
-        const client = new LegacyMongoClient(iLoveJs, {
-          driverInfo: { version: '99.99.99' }
-        });
+      it('should prepend mongodb-legacy to user passed driverInfo.name', () =>
         expect(client.options.metadata)
           .to.have.nested.property('driver.name')
-          .that.equals('nodejs|mongodb-legacy');
+          .that.equals('nodejs|mongodb-legacy'));
+
+      it('should prepend version in package.json to user driverInfo.version', () =>
         expect(client.options.metadata)
           .to.have.property('version')
-          .that.includes(`${currentLegacyVersion}|99.99.99`);
-      });
+          .that.includes(`${currentLegacyVersion}|99.99.99`));
+    });
+
+    describe('when driverInfo is not provided', () => {
+      const client = new LegacyMongoClient(iLoveJs);
+
+      it('should prepend mongodb-legacy to user passed driverInfo.name', () =>
+        expect(client.options.metadata)
+          .to.have.nested.property('driver.name')
+          .that.equals('nodejs|mongodb-legacy'));
+
+      it('should prepend version in package.json to user driverInfo.version', () =>
+        expect(client.options.metadata)
+          .to.have.property('version')
+          .that.includes(currentLegacyVersion));
     });
   });
 

--- a/test/unit/legacy_wrappers/mongo_client.test.js
+++ b/test/unit/legacy_wrappers/mongo_client.test.js
@@ -22,6 +22,24 @@ describe('legacy_wrappers/mongo_client.js', () => {
     await client.close();
   });
 
+  describe('client metadata', () => {
+    it('should set mongodb-legacy to the client metadata', () => {
+      const client = new LegacyMongoClient(iLoveJs);
+      expect(client.options)
+        .to.have.nested.property('metadata.driver.name')
+        .to.be.a('string')
+        .that.includes('mongodb-legacy');
+    });
+
+    it('should add mongodb-legacy to existing driverInfo.name', () => {
+      const client = new LegacyMongoClient(iLoveJs, { driverInfo: { name: 'mongoose' } });
+      expect(client.options)
+        .to.have.nested.property('metadata.driver.name')
+        .to.be.a('string')
+        .that.includes('mongoose|mongodb-legacy');
+    });
+  });
+
   it('calling MongoClient.connect() returns promise', async () => {
     sinon.stub(mongodbDriver.MongoClient.prototype, 'connect').returns(Promise.resolve(2));
     expect(client).to.have.property('connect').that.is.a('function');

--- a/test/unit/legacy_wrappers/mongo_client.test.js
+++ b/test/unit/legacy_wrappers/mongo_client.test.js
@@ -34,7 +34,7 @@ describe('legacy_wrappers/mongo_client.js', () => {
           'nodejs|mongodb-legacy|mongoose'
         ));
 
-      it('should include version in package.json to metadata version', () =>
+      it('should include version in package.json in client metadata', () =>
         expect(client.options.metadata)
           .to.have.property('version')
           .that.includes(currentLegacyVersion));
@@ -61,7 +61,7 @@ describe('legacy_wrappers/mongo_client.js', () => {
         driverInfo: { version: '99.99.99' }
       });
 
-      it('should prepend mongodb-legacy to user passed driverInfo.name', () =>
+      it('should include mongodb-legacy in client metadata', () =>
         expect(client.options.metadata)
           .to.have.nested.property('driver.name')
           .that.equals('nodejs|mongodb-legacy'));
@@ -75,12 +75,12 @@ describe('legacy_wrappers/mongo_client.js', () => {
     describe('when driverInfo is not provided', () => {
       const client = new LegacyMongoClient(iLoveJs);
 
-      it('should prepend mongodb-legacy to user passed driverInfo.name', () =>
+      it('should include mongodb-legacy in client metadata', () =>
         expect(client.options.metadata)
           .to.have.nested.property('driver.name')
           .that.equals('nodejs|mongodb-legacy'));
 
-      it('should prepend version in package.json to user driverInfo.version', () =>
+      it('should include version in package.json in client metadata', () =>
         expect(client.options.metadata)
           .to.have.property('version')
           .that.includes(currentLegacyVersion));

--- a/test/unit/legacy_wrappers/mongo_client.test.js
+++ b/test/unit/legacy_wrappers/mongo_client.test.js
@@ -33,6 +33,18 @@ describe('legacy_wrappers/mongo_client.js', () => {
   });
 
   describe('setting client metadata', () => {
+    it('does not mutate the input options', () => {
+      expect(() => {
+        new LegacyMongoClient(iLoveJs, Object.freeze({}));
+      }).to.not.throw();
+    });
+
+    it('does not mutate the input options.driverInfo', () => {
+      expect(() => {
+        new LegacyMongoClient(iLoveJs, Object.freeze({ driverInfo: Object.freeze({}) }));
+      }).to.not.throw();
+    });
+
     describe('when driverInfo.name is provided', () => {
       const client = new LegacyMongoClient(iLoveJs, { driverInfo: { name: 'mongoose' } });
 


### PR DESCRIPTION
### Description

#### What is changing?

The MongoClient will set the driverInfo.name property to contain `mongodb-legacy`

#### What is the motivation?

To get insight into callback usage

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
