### PR TITLE
fix(NODE-4626): remove nested import logic

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,24 +39,11 @@ const classesWithAsyncAPIs = new Map([
   ['GridFSBucket', makeLegacyGridFSBucket],
   ['ClientSession', makeLegacyClientSession],
   ['MongoClient', makeLegacyMongoClient],
-
-  // Need to be exported top-level still
   ['ClientSession', makeLegacyClientSession],
   ['GridFSBucketWriteStream', makeLegacyGridFSBucketWriteStream],
   ['OrderedBulkOperation', makeLegacyOrderedBulkOperation],
   ['UnorderedBulkOperation', makeLegacyUnorderedBulkOperation]
 ]);
-
-const TODO_SPECIAL_IMPORTS = new Map([
-  ['ClientSession', '/lib/sessions'],
-  ['GridFSBucketWriteStream', '/lib/gridfs/upload'],
-  ['OrderedBulkOperation', '/lib/bulk/ordered'],
-  ['UnorderedBulkOperation', '/lib/bulk/unordered']
-]);
-
-for (const [missingTopLevelClassName, location] of TODO_SPECIAL_IMPORTS) {
-  mongodb[missingTopLevelClassName] = require(`mongodb${location}`)[missingTopLevelClassName];
-}
 
 for (const [mongodbExportName, mongodbExportValue] of Object.entries(mongodb)) {
   let makeLegacyClass = classesWithAsyncAPIs.get(mongodbExportName);


### PR DESCRIPTION
### Description

[NODE-4626](https://jira.mongodb.org/browse/NODE-4626)

#### What is changing?

Removing the old patch nested imports. The current version of the driver fails because we're missing exports, the latest passes because we changed the exports.

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
