### PR TITLE
fix(NODE-5003): cloned cursors are not legacy api

### DIFF
--- a/src/legacy_wrappers/cursors.js
+++ b/src/legacy_wrappers/cursors.js
@@ -7,6 +7,11 @@ module.exports = Object.create(null);
 Object.defineProperty(module.exports, '__esModule', { value: true });
 
 module.exports.makeLegacyFindCursor = function (baseClass) {
+  function toLegacyHelper(cursor) {
+    Object.setPrototypeOf(cursor, LegacyFindCursor.prototype);
+    return cursor;
+  }
+
   class LegacyFindCursor extends baseClass {
     /** @deprecated Use `collection.estimatedDocumentCount` or `collection.countDocuments` instead */
     count(options, callback) {
@@ -56,12 +61,16 @@ module.exports.makeLegacyFindCursor = function (baseClass) {
     tryNext(callback) {
       return maybeCallback(super.tryNext(), callback);
     }
+    clone() {
+      const cursor = super.clone();
+      return toLegacyHelper(cursor);
+    }
   }
 
   Object.defineProperty(baseClass.prototype, toLegacy, {
     enumerable: false,
     value: function () {
-      return Object.setPrototypeOf(this, LegacyFindCursor.prototype);
+      return toLegacyHelper(this);
     }
   });
 
@@ -69,6 +78,11 @@ module.exports.makeLegacyFindCursor = function (baseClass) {
 };
 
 module.exports.makeLegacyListCollectionsCursor = function (baseClass) {
+  function toLegacyHelper(cursor) {
+    Object.setPrototypeOf(cursor, LegacyListCollectionsCursor.prototype);
+    return cursor;
+  }
+
   class LegacyListCollectionsCursor extends baseClass {
     close(options, callback) {
       callback =
@@ -95,12 +109,16 @@ module.exports.makeLegacyListCollectionsCursor = function (baseClass) {
     tryNext(callback) {
       return maybeCallback(super.tryNext(), callback);
     }
+    clone() {
+      const cursor = super.clone();
+      return toLegacyHelper(cursor);
+    }
   }
 
   Object.defineProperty(baseClass.prototype, toLegacy, {
     enumerable: false,
     value: function () {
-      return Object.setPrototypeOf(this, LegacyListCollectionsCursor.prototype);
+      return toLegacyHelper(this);
     }
   });
 
@@ -108,6 +126,11 @@ module.exports.makeLegacyListCollectionsCursor = function (baseClass) {
 };
 
 module.exports.makeLegacyListIndexesCursor = function (baseClass) {
+  function toLegacyHelper(cursor) {
+    Object.setPrototypeOf(cursor, LegacyListIndexesCursor.prototype);
+    return cursor;
+  }
+
   class LegacyListIndexesCursor extends baseClass {
     close(options, callback) {
       callback =
@@ -134,12 +157,16 @@ module.exports.makeLegacyListIndexesCursor = function (baseClass) {
     tryNext(callback) {
       return maybeCallback(super.tryNext(), callback);
     }
+    clone() {
+      const cursor = super.clone();
+      return toLegacyHelper(cursor);
+    }
   }
 
   Object.defineProperty(baseClass.prototype, toLegacy, {
     enumerable: false,
     value: function () {
-      return Object.setPrototypeOf(this, LegacyListIndexesCursor.prototype);
+      return toLegacyHelper(this);
     }
   });
 
@@ -147,6 +174,11 @@ module.exports.makeLegacyListIndexesCursor = function (baseClass) {
 };
 
 module.exports.makeLegacyAggregationCursor = function (baseClass) {
+  function toLegacyHelper(cursor) {
+    Object.setPrototypeOf(cursor, LegacyAggregationCursor.prototype);
+    return cursor;
+  }
+
   class LegacyAggregationCursor extends baseClass {
     explain(verbosity, callback) {
       callback =
@@ -184,12 +216,16 @@ module.exports.makeLegacyAggregationCursor = function (baseClass) {
     tryNext(callback) {
       return maybeCallback(super.tryNext(), callback);
     }
+    clone() {
+      const cursor = super.clone();
+      return toLegacyHelper(cursor);
+    }
   }
 
   Object.defineProperty(baseClass.prototype, toLegacy, {
     enumerable: false,
     value: function () {
-      return Object.setPrototypeOf(this, LegacyAggregationCursor.prototype);
+      return toLegacyHelper(this);
     }
   });
 

--- a/test/tools/api.js
+++ b/test/tools/api.js
@@ -40,6 +40,12 @@ const api = [
   { className: 'Admin', method: 'validateCollection', returnType: 'Promise<Document>' },
 
   { className: 'AggregationCursor', method: 'explain', returnType: 'Promise<Document>' },
+  { className: 'AggregationCursor', method: 'clone', returnType: 'AggregationCursor', notAsync: true },
+
+  { className: 'FindCursor', method: 'clone', returnType: 'FindCursor', notAsync: true },
+  { className: 'ListIndexesCursor', method: 'clone', returnType: 'ListIndexesCursor', notAsync: true },
+  { className: 'ListCollectionsCursor', method: 'clone', returnType: 'ListCollectionsCursor', notAsync: true },
+
 
   // Super class of Unordered/Ordered Bulk operations
   // This is listed here as a reference for completeness, but it is tested by the subclass overrides of execute

--- a/test/unit/legacy_wrappers/collection.test.js
+++ b/test/unit/legacy_wrappers/collection.test.js
@@ -47,7 +47,7 @@ describe('legacy_wrappers/collection.js', () => {
     expect(collection.listIndexes().clone()).to.be.instanceOf(LegacyListIndexesCursor);
   });
 
-  it('collection.aggregate().clone() should return legacy ChangeStream', () => {
+  it('collection.aggregate().clone() should return legacy AggregationCursor', () => {
     expect(collection.aggregate().clone()).to.be.instanceOf(LegacyAggregationCursor);
   });
 

--- a/test/unit/legacy_wrappers/collection.test.js
+++ b/test/unit/legacy_wrappers/collection.test.js
@@ -43,6 +43,18 @@ describe('legacy_wrappers/collection.js', () => {
     expect(collection.find()).to.be.instanceOf(LegacyFindCursor);
   });
 
+  it('collection.listIndexes().clone() should return legacy listIndexes cursor', () => {
+    expect(collection.listIndexes().clone()).to.be.instanceOf(LegacyListIndexesCursor);
+  });
+
+  it('collection.aggregate().clone() should return legacy ChangeStream', () => {
+    expect(collection.aggregate().clone()).to.be.instanceOf(LegacyAggregationCursor);
+  });
+
+  it('collection.find().clone() should return legacy FindCursor', () => {
+    expect(collection.find().clone()).to.be.instanceOf(LegacyFindCursor);
+  });
+
   describe('rename()', () => {
     let client;
     let collection;

--- a/test/unit/legacy_wrappers/db.test.js
+++ b/test/unit/legacy_wrappers/db.test.js
@@ -28,6 +28,10 @@ describe('legacy_wrappers/db.js', () => {
     expect(db.listCollections()).to.be.instanceOf(LegacyListCollectionsCursor);
   });
 
+  it('collection.listCollections().clone() should return legacy listCollections cursor', () => {
+    expect(db.listCollections().clone()).to.be.instanceOf(LegacyListCollectionsCursor);
+  });
+
   it('should return legacy ChangeStream', () => {
     expect(db.watch()).to.be.instanceOf(LegacyChangeStream);
   });

--- a/test/unit/legacy_wrappers/db.test.js
+++ b/test/unit/legacy_wrappers/db.test.js
@@ -28,7 +28,7 @@ describe('legacy_wrappers/db.js', () => {
     expect(db.listCollections()).to.be.instanceOf(LegacyListCollectionsCursor);
   });
 
-  it('collection.listCollections().clone() should return legacy listCollections cursor', () => {
+  it('db.listCollections().clone() should return legacy listCollections cursor', () => {
     expect(db.listCollections().clone()).to.be.instanceOf(LegacyListCollectionsCursor);
   });
 


### PR DESCRIPTION
### Description

#### What is changing?

#11 backport

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
