### PR TITLE
chore(NODE-5387): add release automation

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,15 @@
+name: Setup
+description: 'Installs node, driver dependencies, and builds source'
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 'lts/*'
+        cache: 'npm'
+        registry-url: 'https://registry.npmjs.org'
+    - run: npm install -g npm@latest
+      shell: bash
+    - run: npm clean-install
+      shell: bash

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,6 +16,14 @@ If you haven't already, it would greatly help the team review this work in a tim
 You can do that here: https://jira.mongodb.org/projects/NODE
 -->
 
+### Release Highlight
+
+<!-- RELEASE_HIGHLIGHT_START -->
+
+### Fill in title or leave empty for no highlight
+
+<!-- RELEASE_HIGHLIGHT_END -->
+
 ### Double check the following
 
 - [ ] Ran `npm run check:lint` script

--- a/.github/scripts/highlights.mjs
+++ b/.github/scripts/highlights.mjs
@@ -1,0 +1,79 @@
+// @ts-check
+import * as process from 'node:process';
+import { Octokit } from '@octokit/core';
+import { output } from './util.mjs';
+
+const {
+  GITHUB_TOKEN = '',
+  PR_LIST = '',
+  owner = 'mongodb-js',
+  repo = 'nodejs-mongodb-legacy'
+} = process.env;
+if (GITHUB_TOKEN === '') throw new Error('GITHUB_TOKEN cannot be empty');
+
+const octokit = new Octokit({
+  auth: GITHUB_TOKEN,
+  log: {
+    debug: msg => console.error('Octokit.debug', msg),
+    info: msg => console.error('Octokit.info', msg),
+    warn: msg => console.error('Octokit.warn', msg),
+    error: msg => console.error('Octokit.error', msg)
+  }
+});
+
+const prs = PR_LIST.split(',').map(pr => {
+  const prNum = Number(pr);
+  if (Number.isNaN(prNum))
+    throw Error(`expected PR number list: ${PR_LIST}, offending entry: ${pr}`);
+  return prNum;
+});
+
+/** @param {number} pull_number */
+async function getPullRequestContent(pull_number) {
+  const startIndicator = 'RELEASE_HIGHLIGHT_START -->';
+  const endIndicator = '<!-- RELEASE_HIGHLIGHT_END';
+
+  let body;
+  try {
+    const res = await octokit.request('GET /repos/{owner}/{repo}/pulls/{pull_number}', {
+      owner,
+      repo,
+      pull_number,
+      headers: { 'X-GitHub-Api-Version': '2022-11-28' }
+    });
+    body = res.data.body;
+  } catch (error) {
+    console.log(`Could not get PR ${pull_number}, skipping. ${error.status}`);
+    return '';
+  }
+
+  if (body == null || !(body.includes(startIndicator) && body.includes(endIndicator))) {
+    console.log(`PR #${pull_number} has no highlight`);
+    return '';
+  }
+
+  const start = body.indexOf('### ', body.indexOf(startIndicator));
+  const end = body.indexOf(endIndicator);
+  const highlightSection = body.slice(start, end).trim();
+
+  console.log(`PR #${pull_number} has a highlight ${highlightSection.length} characters long`);
+  return highlightSection;
+}
+
+/** @param {number[]} prs */
+async function pullRequestHighlights(prs) {
+  const highlights = [];
+  for (const pr of prs) {
+    const content = await getPullRequestContent(pr);
+    highlights.push(content);
+  }
+  if (!highlights.length) return '';
+
+  highlights.unshift('## Release Notes\n\n');
+  return highlights.join('\n\n');
+}
+
+console.log('List of PRs to collect highlights from:', prs);
+const highlights = await pullRequestHighlights(prs);
+
+await output('highlights', JSON.stringify({ highlights }));

--- a/.github/scripts/pr_list.mjs
+++ b/.github/scripts/pr_list.mjs
@@ -12,7 +12,7 @@ const historyFilePath = path.join(__dirname, '..', '..', 'HISTORY.md');
  * @returns {string[]}
  */
 function parsePRList(history) {
-  const prRegexp = /node-mongodb-native\/issues\/(?<prNum>\d+)\)/iu;
+  const prRegexp = /mongodb-legacy/issues\/(?<prNum>\d+)\)/iu;
   return history
     .split('\n')
     .map(line => prRegexp.exec(line)?.groups?.prNum ?? '')

--- a/.github/scripts/pr_list.mjs
+++ b/.github/scripts/pr_list.mjs
@@ -1,0 +1,28 @@
+// @ts-check
+import * as url from 'node:url';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { getCurrentHistorySection, output } from './util.mjs';
+
+const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
+const historyFilePath = path.join(__dirname, '..', '..', 'HISTORY.md');
+
+/**
+ * @param {string} history
+ * @returns {string[]}
+ */
+function parsePRList(history) {
+  const prRegexp = /node-mongodb-native\/issues\/(?<prNum>\d+)\)/iu;
+  return history
+    .split('\n')
+    .map(line => prRegexp.exec(line)?.groups?.prNum ?? '')
+    .filter(prNum => prNum !== '');
+}
+
+const historyContents = await fs.readFile(historyFilePath, { encoding: 'utf8' });
+
+const currentHistorySection = getCurrentHistorySection(historyContents);
+
+const prs = parsePRList(currentHistorySection);
+
+await output('pr_list', prs.join(','));

--- a/.github/scripts/release_notes.mjs
+++ b/.github/scripts/release_notes.mjs
@@ -1,0 +1,56 @@
+//@ts-check
+import * as url from 'node:url';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as process from 'node:process';
+import * as semver from 'semver';
+import { getCurrentHistorySection, output } from './util.mjs';
+
+const { HIGHLIGHTS = '' } = process.env;
+if (HIGHLIGHTS === '') throw new Error('HIGHLIGHTS cannot be empty');
+
+const { highlights } = JSON.parse(HIGHLIGHTS);
+
+const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
+const historyFilePath = path.join(__dirname, '..', '..', 'HISTORY.md');
+const packageFilePath = path.join(__dirname, '..', '..', 'package.json');
+
+const historyContents = await fs.readFile(historyFilePath, { encoding: 'utf8' });
+
+const currentHistorySection = getCurrentHistorySection(historyContents);
+
+const version = semver.parse(
+  JSON.parse(await fs.readFile(packageFilePath, { encoding: 'utf8' })).version
+);
+if (version == null) throw new Error(`could not create semver from package.json`);
+
+console.log('\n\n--- history entry ---\n\n', currentHistorySection);
+
+const currentHistorySectionLines = currentHistorySection.split('\n');
+const header = currentHistorySectionLines[0];
+const history = currentHistorySectionLines.slice(1).join('\n').trim();
+
+const releaseNotes = `${header}
+
+The MongoDB Node.js team is pleased to announce version ${version.version} of the \`mongodb\` package!
+
+${highlights}
+${history}
+## Documentation
+
+* [Reference](https://docs.mongodb.com/drivers/node/current/)
+* [API](https://mongodb.github.io/node-mongodb-native/${version.major}.${version.minor}/)
+* [Changelog](https://github.com/mongodb/node-mongodb-native/blob/v${version.version}/HISTORY.md)
+
+We invite you to try the \`mongodb\` library immediately, and report any issues to the [NODE project](https://jira.mongodb.org/projects/NODE).
+`;
+
+const releaseNotesPath = path.join(process.cwd(), 'release_notes.md');
+
+await fs.writeFile(
+  releaseNotesPath,
+  `:seedling: A new release!\n---\n${releaseNotes}\n---\n`,
+  { encoding:'utf8' }
+);
+
+await output('release_notes_path', releaseNotesPath)

--- a/.github/scripts/release_notes.mjs
+++ b/.github/scripts/release_notes.mjs
@@ -32,7 +32,7 @@ const history = currentHistorySectionLines.slice(1).join('\n').trim();
 
 const releaseNotes = `${header}
 
-The MongoDB Node.js team is pleased to announce version ${version.version} of the \`mongodb\` package!
+The MongoDB Node.js team is pleased to announce version ${version.version} of the \`mongodb-legacy\` package!
 
 ${highlights}
 ${history}
@@ -42,7 +42,7 @@ ${history}
 * [API](https://mongodb.github.io/node-mongodb-native/${version.major}.${version.minor}/)
 * [Changelog](https://github.com/mongodb/node-mongodb-native/blob/v${version.version}/HISTORY.md)
 
-We invite you to try the \`mongodb\` library immediately, and report any issues to the [NODE project](https://jira.mongodb.org/projects/NODE).
+We invite you to try the \`mongodb-legacy\` library immediately, and report any issues to the [NODE project](https://jira.mongodb.org/projects/NODE).
 `;
 
 const releaseNotesPath = path.join(process.cwd(), 'release_notes.md');

--- a/.github/scripts/util.mjs
+++ b/.github/scripts/util.mjs
@@ -1,0 +1,47 @@
+// @ts-check
+import * as process from 'node:process';
+import * as fs from 'node:fs/promises';
+
+export async function output(key, value) {
+  const { GITHUB_OUTPUT = '' } = process.env;
+  const output = `${key}=${value}\n`;
+  console.log('outputting:', output);
+
+  if (GITHUB_OUTPUT.length === 0) {
+    // This is always defined in Github actions, and if it is not for some reason, tasks that follow will fail.
+    // For local testing it's convenient to see what scripts would output without requiring the variable to be defined.
+    console.log('GITHUB_OUTPUT not defined, printing only');
+    return;
+  }
+
+  const outputFile = await fs.open(GITHUB_OUTPUT, 'a');
+  await outputFile.appendFile(output, { encoding: 'utf8' });
+  await outputFile.close();
+}
+
+/**
+ * @param {string} historyContents
+ * @returns {string}
+ */
+export function getCurrentHistorySection(historyContents) {
+  /** Markdown version header */
+  const VERSION_HEADER = /^#.+\(\d{4}-\d{2}-\d{2}\)$/g;
+
+  const historyLines = historyContents.split('\n');
+
+  // Search for the line with the first version header, this will be the one we're releasing
+  const headerLineIndex = historyLines.findIndex(line => VERSION_HEADER.test(line));
+  if (headerLineIndex < 0) throw new Error('Could not find any version header');
+
+  console.log('Found markdown header current release', headerLineIndex, ':', historyLines[headerLineIndex]);
+
+  // Search lines starting after the first header, and add back the offset we sliced at
+  const nextHeaderLineIndex = historyLines
+    .slice(headerLineIndex + 1)
+    .findIndex(line => VERSION_HEADER.test(line)) + headerLineIndex + 1;
+  if (nextHeaderLineIndex < 0) throw new Error(`Could not find previous version header, searched ${headerLineIndex + 1}`);
+
+  console.log('Found markdown header previous release', nextHeaderLineIndex, ':', historyLines[nextHeaderLineIndex]);
+
+  return historyLines.slice(headerLineIndex, nextHeaderLineIndex).join('\n');
+}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,9 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js LTS
-        uses: actions/setup-node@v3
-        with:
-          node-version: lts/*
-      - run: npm clean-install
+
+      - name: actions/setup
+        uses: ./.github/actions/setup
+
       - run: npm run check:lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+name: release
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - id: release
+        uses: google-github-actions/release-please-action@v3
+        with:
+          release-type: node
+          package-name: mongodb
+          # Example: chore(main): release 5.7.0 [skip-ci]
+          # ${scope} - parenthesis included, base branch name
+          pull-request-title-pattern: 'chore${scope}: release ${version} [skip-ci]'
+          pull-request-header: 'Please run the release_notes action before releasing to generate release highlights'
+          changelog-path: HISTORY.md
+          default-branch: main
+
+      # If release-please created a release, publish to npm
+      - if: ${{ steps.release.outputs.release_created }}
+        uses: actions/checkout@v3
+      - if: ${{ steps.release.outputs.release_created }}
+        name: actions/setup
+        uses: ./.github/actions/setup
+      - if: ${{ steps.release.outputs.release_created }}
+        run: npm publish --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
         uses: google-github-actions/release-please-action@v3
         with:
           release-type: node
-          package-name: mongodb
+          package-name: mongodb-legacy
           # Example: chore(main): release 5.7.0 [skip-ci]
           # ${scope} - parenthesis included, base branch name
           pull-request-title-pattern: 'chore${scope}: release ${version} [skip-ci]'

--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -1,0 +1,48 @@
+name: release_notes
+
+on:
+  workflow_dispatch:
+    inputs:
+      releasePr:
+        description: 'Enter release PR number'
+        required: true
+        type: number
+
+jobs:
+  release_notes:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: actions/setup
+        uses: ./.github/actions/setup
+
+      # See: https://github.com/googleapis/release-please/issues/1274
+
+      # Get the PRs that are in this release
+      # Outputs a list of comma seperated PR numbers, parsed from HISTORY.md
+      - id: pr_list
+        run: node .github/scripts/pr_list.mjs
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      # From the list of PRs, gather the highlight sections of the PR body
+      # output JSON with "highlights" key (to preserve newlines)
+      - id: highlights
+        run: node .github/scripts/highlights.mjs
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_LIST: ${{ steps.pr_list.outputs.pr_list }}
+
+      # The combined output is available
+      - id: release_notes
+        run: node .github/scripts/release_notes.mjs
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          HIGHLIGHTS: ${{ steps.highlights.outputs.highlights }}
+
+      # Update the release PR body
+      - run: gh pr edit ${{ inputs.releasePr }} --body-file ${{ steps.release_notes.outputs.release_notes_path }}
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@microsoft/api-extractor-model": "^7.26.7",
+        "@octokit/core": "^4.2.4",
         "@typescript-eslint/eslint-plugin": "^5.59.2",
         "@typescript-eslint/parser": "^5.59.2",
         "chai": "^4.3.7",
@@ -839,6 +840,107 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@octokit/auth-token": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.4.tgz",
+      "integrity": "sha512-TWFX7cZF2LXoCvdmJWY7XVPi74aSY0+FfBZNSXEXFkMpjcqsQwDSYVv5FhRFaI0V1ECnwbz4j59T/G+rXNWaIQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.2.4.tgz",
+      "integrity": "sha512-rYKilwgzQ7/imScn3M9/pFfUf4I1AZEH3KhyJmtPdE2zfaXAn2mFfUy4FbKewzc2We5y/LlKLj36fWJLKC2SIQ==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/auth-token": "^3.0.0",
+        "@octokit/graphql": "^5.0.0",
+        "@octokit/request": "^6.0.0",
+        "@octokit/request-error": "^3.0.0",
+        "@octokit/types": "^9.0.0",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.6.tgz",
+      "integrity": "sha512-5L4fseVRUsDFGR00tMWD/Trdeeihn999rTMGRMC1G/Ldi1uWlWJzI98H4Iak5DB/RVvQuyMYKqSK/R6mbSOQyg==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/types": "^9.0.0",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-5.0.6.tgz",
+      "integrity": "sha512-Fxyxdy/JH0MnIB5h+UQ3yCoh1FG4kWXfFKkpWqjZHw/p+Kc8Y44Hu/kCgNBT6nU1shNumEchmW/sUO1JuQnPcw==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/request": "^6.0.0",
+        "@octokit/types": "^9.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-18.0.0.tgz",
+      "integrity": "sha512-V8GImKs3TeQRxRtXFpG2wl19V7444NIOTDF24AWuIbmNaNYOQMWRbjcGDXV5B+0n887fgDcuMNOmlul+k+oJtw==",
+      "dev": true
+    },
+    "node_modules/@octokit/request": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.8.tgz",
+      "integrity": "sha512-ow4+pkVQ+6XVVsekSYBzJC0VTVvh/FCTUUgTsboGq+DTeWdyIFV8WSCdo0RIxk6wSkBTHqIK1mYuY7nOBXOchw==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/endpoint": "^7.0.0",
+        "@octokit/request-error": "^3.0.0",
+        "@octokit/types": "^9.0.0",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.3.tgz",
+      "integrity": "sha512-crqw3V5Iy2uOU5Np+8M/YexTlT8zxCfI+qu+LxUB7SZpje4Qmx3mub5DfEKSO8Ylyk0aogi6TYdf6kxzh2BguQ==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/types": "^9.0.0",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
+      "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/openapi-types": "^18.0.0"
+      }
+    },
     "node_modules/@rushstack/node-core-library": {
       "version": "3.58.0",
       "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.58.0.tgz",
@@ -1349,6 +1451,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/before-after-hook": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+      "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
       "dev": true
     },
     "node_modules/binary-extensions": {
@@ -2109,6 +2217,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+      "dev": true
     },
     "node_modules/detect-indent": {
       "version": "6.1.0",
@@ -3394,6 +3508,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -4284,6 +4407,48 @@
       "dev": true,
       "dependencies": {
         "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/node-preload": {
@@ -5921,6 +6086,12 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/universal-user-agent": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
+      "dev": true
+    },
     "node_modules/universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -6861,6 +7032,89 @@
         "fastq": "^1.6.0"
       }
     },
+    "@octokit/auth-token": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.4.tgz",
+      "integrity": "sha512-TWFX7cZF2LXoCvdmJWY7XVPi74aSY0+FfBZNSXEXFkMpjcqsQwDSYVv5FhRFaI0V1ECnwbz4j59T/G+rXNWaIQ==",
+      "dev": true
+    },
+    "@octokit/core": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.2.4.tgz",
+      "integrity": "sha512-rYKilwgzQ7/imScn3M9/pFfUf4I1AZEH3KhyJmtPdE2zfaXAn2mFfUy4FbKewzc2We5y/LlKLj36fWJLKC2SIQ==",
+      "dev": true,
+      "requires": {
+        "@octokit/auth-token": "^3.0.0",
+        "@octokit/graphql": "^5.0.0",
+        "@octokit/request": "^6.0.0",
+        "@octokit/request-error": "^3.0.0",
+        "@octokit/types": "^9.0.0",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/endpoint": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.6.tgz",
+      "integrity": "sha512-5L4fseVRUsDFGR00tMWD/Trdeeihn999rTMGRMC1G/Ldi1uWlWJzI98H4Iak5DB/RVvQuyMYKqSK/R6mbSOQyg==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^9.0.0",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/graphql": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-5.0.6.tgz",
+      "integrity": "sha512-Fxyxdy/JH0MnIB5h+UQ3yCoh1FG4kWXfFKkpWqjZHw/p+Kc8Y44Hu/kCgNBT6nU1shNumEchmW/sUO1JuQnPcw==",
+      "dev": true,
+      "requires": {
+        "@octokit/request": "^6.0.0",
+        "@octokit/types": "^9.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/openapi-types": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-18.0.0.tgz",
+      "integrity": "sha512-V8GImKs3TeQRxRtXFpG2wl19V7444NIOTDF24AWuIbmNaNYOQMWRbjcGDXV5B+0n887fgDcuMNOmlul+k+oJtw==",
+      "dev": true
+    },
+    "@octokit/request": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.8.tgz",
+      "integrity": "sha512-ow4+pkVQ+6XVVsekSYBzJC0VTVvh/FCTUUgTsboGq+DTeWdyIFV8WSCdo0RIxk6wSkBTHqIK1mYuY7nOBXOchw==",
+      "dev": true,
+      "requires": {
+        "@octokit/endpoint": "^7.0.0",
+        "@octokit/request-error": "^3.0.0",
+        "@octokit/types": "^9.0.0",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/request-error": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.3.tgz",
+      "integrity": "sha512-crqw3V5Iy2uOU5Np+8M/YexTlT8zxCfI+qu+LxUB7SZpje4Qmx3mub5DfEKSO8Ylyk0aogi6TYdf6kxzh2BguQ==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^9.0.0",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "@octokit/types": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
+      "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
+      "dev": true,
+      "requires": {
+        "@octokit/openapi-types": "^18.0.0"
+      }
+    },
     "@rushstack/node-core-library": {
       "version": "3.58.0",
       "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.58.0.tgz",
@@ -7233,6 +7487,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "before-after-hook": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+      "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
       "dev": true
     },
     "binary-extensions": {
@@ -7809,6 +8069,12 @@
           "dev": true
         }
       }
+    },
+    "deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+      "dev": true
     },
     "detect-indent": {
       "version": "6.1.0",
@@ -8779,6 +9045,12 @@
       "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
       "dev": true
     },
+    "is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true
+    },
     "is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -9464,6 +9736,39 @@
           "dev": true,
           "requires": {
             "type-detect": "4.0.8"
+          }
+        }
+      }
+    },
+    "node-fetch": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
+      "dev": true,
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+          "dev": true
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+          "dev": true,
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
           }
         }
       }
@@ -10679,6 +10984,12 @@
       "integrity": "sha512-aTeNPVmgIMPpm1cxXr2Q/nEbvkmV8yq66F3om7X3P/cvOXQ0TMQ64Wk63iyT1gPlmdmGzjGpyLh1f3y8MZWXGg==",
       "dev": true,
       "optional": true
+    },
+    "universal-user-agent": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
+      "dev": true
     },
     "universalify": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@microsoft/api-extractor-model": "^7.26.7",
+    "@octokit/core": "^4.2.4",
     "@typescript-eslint/eslint-plugin": "^5.59.2",
     "@typescript-eslint/parser": "^5.59.2",
     "chai": "^4.3.7",


### PR DESCRIPTION
### Description

#### What is changing?

Adds release automation from driver

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

- Provenance release automation
- Release notes generation

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->
<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
