### PR TITLE
chore(NODE-5476): move id-token permission to workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,14 +6,13 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 name: release
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
     steps:
       - id: release
         uses: google-github-actions/release-please-action@v3


### PR DESCRIPTION
### Description

#### What is changing?

Move permissions, make release work again

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
