### PR TITLE
docs(NODE-5529): add driver compat table

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -67,9 +67,18 @@ npm install mongodb-legacy
 We recommend replacing your `mongodb` dependency with this one.
 This package uses caret semver range for the main `mongodb` package, (ex. `^4.10.0`) which will adopt minor version bumps as they are released.
 
-The next major release of the driver (v5) will drop support for callbacks.
-This package will also have a major release at that time to update the dependency requirement to `^5.0.0`.
-Users can expect to be able to upgrade to `v5` adopting the changes and features shipped in that version while using this module to maintain any callback code they still need to work on migrating.
+Users can expect to be able to upgrade to `v5` or later adopting the changes and features shipped in that version while using this module to maintain any callback code they still need to work on migrating.
+
+#### MongoDB Node.js Driver Version Compatibility Table
+
+The following version combinations with the [MongoDB Node.js Driver](https://github.com/mongodb/node-mongodb-native) are considered stable.
+
+|               | `mongodb-legacy@4.x` | `mongodb-legacy@5.x` | `mongodb-legacy@6.x` |
+| ------------- | -------------------- | -------------------- | -------------------- |
+| `mongodb@6.x` | N/A                  | N/A                  | ✓                    |
+| `mongodb@5.x` | N/A                  | ✓                    | N/A                  |
+| `mongodb@4.x` | ✓                    | N/A                  | N/A                  |
+| `mongodb@3.x` | N/A                  | N/A                  | N/A                  |
 
 ## [API](https://mongodb.github.io/node-mongodb-native/)
 


### PR DESCRIPTION
### Description
NODE-5529

#### What is changing?
Added table with version compat info for the nodejs driver

##### Is there new documentation needed for these changes?
This is documentation

#### What is the motivation for this change?
Clarity about add-on compatibility

### Release Highlight - N/A

<!-- RELEASE_HIGHLIGHT_START -->

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [N/A] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [N/A] Changes are covered by tests
- [N/A] New TODOs have a related JIRA ticket
