### PR TITLE
feat(NODE-5585)!: adopt mongodb driver v6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "mongodb": "^6.0.0-alpha.2"
+        "mongodb": "^6.0.0"
       },
       "devDependencies": {
         "@microsoft/api-extractor-model": "^7.27.6",
@@ -1523,9 +1523,9 @@
       }
     },
     "node_modules/bson": {
-      "version": "6.0.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-6.0.0-alpha.1.tgz",
-      "integrity": "sha512-uyXUphm103PYF5hEAV8r06S7plgvfaKRPMC4RV3rZVh204oN3tZtcrY1Mg7/YCr68BgVNYUdxeqMO/2gJoYysQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.0.0.tgz",
+      "integrity": "sha512-FoWvdELfF2wQaUo8S/a1Rh2BDwJEUancDDnzdTpYymJTZjmvRpLWoqRPelKn+XSeh5D4YddWDG66cLtEhGGvcg==",
       "engines": {
         "node": ">=16.20.1"
       }
@@ -4310,12 +4310,12 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "6.0.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.0.0-alpha.2.tgz",
-      "integrity": "sha512-rIYIXzSIckNYtAcEN9OPdq4rtA1WZlNdsadyvE7qHU/bQtKz+HhbY7nAy1zLLdOXlZz4i9IOn72YjGkAJqO/9g==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.0.0.tgz",
+      "integrity": "sha512-wUIYesF4DTyDccm0noE5TwGi9ISdXUAi9T2cQ4xPc+EUBZG44bfMVt2ecOG5Ypca7eCz3oRpJm6YI6c7jAnuNw==",
       "dependencies": {
         "@mongodb-js/saslprep": "^1.1.0",
-        "bson": "^6.0.0-alpha.1",
+        "bson": "^6.0.0",
         "mongodb-connection-string-url": "^2.6.0"
       },
       "engines": {
@@ -4326,7 +4326,7 @@
         "@mongodb-js/zstd": "^1.1.0",
         "gcp-metadata": "^5.2.0",
         "kerberos": "^2.0.1",
-        "mongodb-client-encryption": ">=6.0.0-alpha.3 <7",
+        "mongodb-client-encryption": ">=6.0.0 <7",
         "snappy": "^7.2.2",
         "socks": "^2.7.1"
       },
@@ -7539,9 +7539,9 @@
       }
     },
     "bson": {
-      "version": "6.0.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-6.0.0-alpha.1.tgz",
-      "integrity": "sha512-uyXUphm103PYF5hEAV8r06S7plgvfaKRPMC4RV3rZVh204oN3tZtcrY1Mg7/YCr68BgVNYUdxeqMO/2gJoYysQ=="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.0.0.tgz",
+      "integrity": "sha512-FoWvdELfF2wQaUo8S/a1Rh2BDwJEUancDDnzdTpYymJTZjmvRpLWoqRPelKn+XSeh5D4YddWDG66cLtEhGGvcg=="
     },
     "buffer-from": {
       "version": "1.1.2",
@@ -9668,12 +9668,12 @@
       "dev": true
     },
     "mongodb": {
-      "version": "6.0.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.0.0-alpha.2.tgz",
-      "integrity": "sha512-rIYIXzSIckNYtAcEN9OPdq4rtA1WZlNdsadyvE7qHU/bQtKz+HhbY7nAy1zLLdOXlZz4i9IOn72YjGkAJqO/9g==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.0.0.tgz",
+      "integrity": "sha512-wUIYesF4DTyDccm0noE5TwGi9ISdXUAi9T2cQ4xPc+EUBZG44bfMVt2ecOG5Ypca7eCz3oRpJm6YI6c7jAnuNw==",
       "requires": {
         "@mongodb-js/saslprep": "^1.1.0",
-        "bson": "^6.0.0-alpha.1",
+        "bson": "^6.0.0",
         "mongodb-connection-string-url": "^2.6.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "node": ">=16.20.1"
   },
   "dependencies": {
-    "mongodb": "^6.0.0-alpha.2"
+    "mongodb": "^6.0.0"
   },
   "scripts": {
     "check:coverage": "nyc --check-coverage npm run check:test",


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

- Provide a callback version of driver v6

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Adopt MongoDB Node.js Driver v6

v6.0.0 of this package depends on driver version `^6.0.0`. It can be used to migrate existing callback using codebases to promises incrementally while pulling in the latest and greatest MongoDB has to offer!

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
