### PR TITLE
chore: fix pr_list script

### DIFF
--- a/.github/scripts/pr_list.mjs
+++ b/.github/scripts/pr_list.mjs
@@ -12,11 +12,15 @@ const historyFilePath = path.join(__dirname, '..', '..', 'HISTORY.md');
  * @returns {string[]}
  */
 function parsePRList(history) {
-  const prRegexp = /mongodb-legacy/issues\/(?<prNum>\d+)\)/iu;
-  return history
-    .split('\n')
-    .map(line => prRegexp.exec(line)?.groups?.prNum ?? '')
-    .filter(prNum => prNum !== '');
+  const prRegexp = /mongodb-legacy\/issues\/(?<prNum>\d+)\)/iu;
+  return Array.from(
+    new Set(
+      history
+        .split('\n')
+        .map(line => prRegexp.exec(line)?.groups?.prNum ?? '')
+        .filter(prNum => prNum !== '')
+    )
+  );
 }
 
 const historyContents = await fs.readFile(historyFilePath, { encoding: 'utf8' });


### PR DESCRIPTION
### Description

#### What is changing?

- dedupe pr list
- fix regexp

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

N/a

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
