### PR TITLE
chore(NODE-5593): add repository field

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
     "src",
     "mongodb-legacy.d.ts"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:mongodb-js/nodejs-mongodb-legacy.git"
+  },
   "main": "src/index.js",
   "types": "mongodb-legacy.d.ts",
   "engines": {


### PR DESCRIPTION
### Description

Adds repository field to package.json

#### What is changing?

Add repository field, checked with `npm run release -- --dry-run` to verify:

```
> $ npm run release -- --dry-run                                                                      ⬡ 18.12.1 [±NODE-5593 ●]

> mongodb-legacy@6.0.0 release
> standard-version -a -i HISTORY.md --dry-run

✔ bumping version in package.json from 6.0.0 to 6.0.1
✔ bumping version in package-lock.json from 6.0.0 to 6.0.1
✔ outputting changes to HISTORY.md

---
### [6.0.1](https://github.com/mongodb-js/nodejs-mongodb-legacy/compare/v6.0.0...v6.0.1) (2023-10-12)
---

✔ committing package-lock.json and package.json and HISTORY.md and all staged files
✔ tagging release v6.0.1
ℹ Run `git push --follow-tags origin NODE-5593 && npm publish` to publish
```

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-5593

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
