### PR TITLE
feat(NODE-6158): add signature to github releases

### DIFF
--- a/.github/actions/compress_sign_and_upload/action.yml
+++ b/.github/actions/compress_sign_and_upload/action.yml
@@ -22,7 +22,7 @@ runs:
       shell: bash
 
     - name: Get release version and release package file name
-      id: vars
+      id: get_vars
       shell: bash
       run: |
         package_version=$(jq --raw-output '.version' package.json)
@@ -31,12 +31,14 @@ runs:
     - name: Create detached signature
       uses: mongodb-labs/drivers-github-tools/garasign/gpg-sign@v1
       with:
-        filenames: ${{ steps.vars.package_file }}
+        filenames: ${{ steps.get_vars.outputs.package_file }}
         garasign_username: ${{ inputs.garasign_username }}
         garasign_password: ${{ inputs.garasign_password }}
         artifactory_username: ${{ inputs.artifactory_username }}
         artifactory_password: ${{ inputs.artifactory_password }}
 
     - name: "Upload release artifacts"
-      run: gh release upload v${{ steps.vars.package_version }} ${{ steps.vars.package_file }}.sig
+      run: gh release upload v${{ steps.get_vars.outputs.package_version }} ${{ steps.get_vars.outputs.package_file }}.sig
       shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}

--- a/.github/actions/compress_sign_and_upload/action.yml
+++ b/.github/actions/compress_sign_and_upload/action.yml
@@ -1,0 +1,42 @@
+name: Compress and Sign
+description: 'Compresses package and signs with garasign'
+
+inputs: 
+    garasign_username:
+      description: 'Garasign username input for drivers-github-tools/garasign/gpg-sign'
+      required: true
+    garasign_password:
+      description: 'Garasign password input for drivers-github-tools/garasign/gpg-sign'
+      required: true
+    artifactory_username:
+      description: 'Artifactory username input for drivers-github-tools/garasign/gpg-sign'
+      required: true
+    artifactory_password:
+      description: 'Artifactory password input for drivers-github-tools/garasign/gpg-sign'
+      required: true
+
+runs:
+  using: composite
+  steps:
+    - run: npm pack
+      shell: bash
+
+    - name: Get release version and release package file name
+      id: vars
+      shell: bash
+      run: |
+        package_version=$(jq --raw-output '.version' package.json)
+        echo "package_version=${package_version}" >> "$GITHUB_OUTPUT"
+        echo "package_file=mongodb-legacy-${package_version}.tgz" >> "$GITHUB_OUTPUT"
+    - name: Create detached signature
+      uses: mongodb-labs/drivers-github-tools/garasign/gpg-sign@v1
+      with:
+        filenames: ${{ steps.vars.package_file }}
+        garasign_username: ${{ inputs.garasign_username }}
+        garasign_password: ${{ inputs.garasign_password }}
+        artifactory_username: ${{ inputs.artifactory_username }}
+        artifactory_password: ${{ inputs.artifactory_password }}
+
+    - name: "Upload release artifacts"
+      run: gh release upload v${{ steps.vars.package_version }} ${{ steps.vars.package_file }}.sig
+      shell: bash

--- a/.github/actions/compress_sign_and_upload/action.yml
+++ b/.github/actions/compress_sign_and_upload/action.yml
@@ -2,17 +2,17 @@ name: Compress and Sign
 description: 'Compresses package and signs with garasign'
 
 inputs: 
-    garasign_username:
-      description: 'Garasign username input for drivers-github-tools/garasign/gpg-sign'
+    aws_role_arn:
+      description: 'AWS role input for drivers-github-tools/gpg-sign@v2'
       required: true
-    garasign_password:
-      description: 'Garasign password input for drivers-github-tools/garasign/gpg-sign'
+    aws_region_name:
+      description: 'AWS region name input for drivers-github-tools/gpg-sign@v2'
       required: true
-    artifactory_username:
-      description: 'Artifactory username input for drivers-github-tools/garasign/gpg-sign'
+    aws_secret_id:
+      description: 'AWS secret id input for drivers-github-tools/gpg-sign@v2'
       required: true
-    artifactory_password:
-      description: 'Artifactory password input for drivers-github-tools/garasign/gpg-sign'
+    npm_package_name:
+      description: 'The name for the npm package this repository represents'
       required: true
 
 runs:
@@ -27,15 +27,25 @@ runs:
       run: |
         package_version=$(jq --raw-output '.version' package.json)
         echo "package_version=${package_version}" >> "$GITHUB_OUTPUT"
-        echo "package_file=mongodb-legacy-${package_version}.tgz" >> "$GITHUB_OUTPUT"
+        echo "package_file=${{ inputs.npm_package_name }}-${package_version}.tgz" >> "$GITHUB_OUTPUT"
+
+    - name: Set up drivers-github-tools
+      uses: mongodb-labs/drivers-github-tools/setup@v2
+      with: 
+        aws_region_name: ${{ inputs.aws_region_name }}
+        aws_role_arn: ${{ inputs.aws_role_arn }}
+        aws_secret_id: ${{ inputs.aws_secret_id }}
+
     - name: Create detached signature
-      uses: mongodb-labs/drivers-github-tools/garasign/gpg-sign@v1
-      with:
+      uses: mongodb-labs/drivers-github-tools/gpg-sign@v2
+      with: 
         filenames: ${{ steps.get_vars.outputs.package_file }}
-        garasign_username: ${{ inputs.garasign_username }}
-        garasign_password: ${{ inputs.garasign_password }}
-        artifactory_username: ${{ inputs.artifactory_username }}
-        artifactory_password: ${{ inputs.artifactory_password }}
+      env: 
+        RELEASE_ASSETS: ${{ steps.get_vars.outputs.package_file }}.temp.sig
+
+    - name: Name release asset correctly 
+      run: mv ${{ steps.get_vars.outputs.package_file }}.temp.sig ${{ steps.get_vars.outputs.package_file }}.sig
+      shell: bash
 
     - name: "Upload release artifacts"
       run: gh release upload v${{ steps.get_vars.outputs.package_version }} ${{ steps.get_vars.outputs.package_file }}.sig

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
 
   compress_sign_and_upload:
     needs: [release_please]
+    if: ${{ needs.release_please.outputs.release_created }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
     steps:
       - id: release
-        uses: google-github-actions/release-please-action@v4
+        uses: googleapis/release-please-action@v4
 
   compress_sign_and_upload:
     needs: [release_please]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,19 +11,28 @@ permissions:
 name: release
 
 jobs:
-  release-please:
+  release_please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
     steps:
       - id: release
         uses: google-github-actions/release-please-action@v4
 
-      # If release-please created a release, publish to npm
-      - if: ${{ steps.release.outputs.release_created }}
-        uses: actions/checkout@v4
-      - if: ${{ steps.release.outputs.release_created }}
-        name: actions/setup
+  compress_sign_and_upload:
+    needs: [release_please]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: actions/setup
         uses: ./.github/actions/setup
-      - if: ${{ steps.release.outputs.release_created }}
-        run: npm publish --provenance
+      - name: actions/compress_sign_and_upload
+        uses: ./.github/actions/compress_sign_and_upload
+        with: 
+          garasign_username: ${{ secrets.GRS_CONFIG_USER1_USERNAME }}
+          garasign_password: ${{ secrets.GRS_CONFIG_USER1_PASSWORD }}
+          artifactory_username: ${{ secrets.ARTIFACTORY_USER }}
+          artifactory_password: ${{ secrets.ARTIFACTORY_PASSWORD }}
+      - run: npm publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
   compress_sign_and_upload:
     needs: [release_please]
     if: ${{ needs.release_please.outputs.release_created }}
+    environment: release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -30,10 +31,10 @@ jobs:
       - name: actions/compress_sign_and_upload
         uses: ./.github/actions/compress_sign_and_upload
         with: 
-          garasign_username: ${{ secrets.GRS_CONFIG_USER1_USERNAME }}
-          garasign_password: ${{ secrets.GRS_CONFIG_USER1_PASSWORD }}
-          artifactory_username: ${{ secrets.ARTIFACTORY_USER }}
-          artifactory_password: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
+          aws_region_name: 'us-east-1'
+          aws_secret_id: ${{ secrets.AWS_SECRET_ID }}
+          npm_package_name: 'mongodb-legacy'
       - run: npm publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/readme.md
+++ b/readme.md
@@ -66,18 +66,18 @@ npm install mongodb-legacy
 ### Release Integrity
 
 The GitHub release contains a detached signature file for the NPM package (named
-`bson-X.Y.Z.tgz.sig`).
+`mongodb-legacy-X.Y.Z.tgz.sig`).
 
 The following command returns the link npm package. 
 ```shell
-npm view mongodb@vX.Y.Z dist.tarball 
+npm view mongodb-legacy@vX.Y.Z dist.tarball 
 ```
 
 Using the result of the above command, a `curl` command can return the official npm package for the release.
 
 To verify the integrity of the downloaded package, run the following command:
 ```shell
-gpg --verify mongodb-X.Y.Z.tgz.sig mongodb-X.Y.Z.tgz
+gpg --verify mongodb-legacy-X.Y.Z.tgz.sig mongodb-legacy-X.Y.Z.tgz
 ```
 
 ### Versioning

--- a/readme.md
+++ b/readme.md
@@ -62,6 +62,24 @@ In your existing project add `mongodb-legacy` to your `package.json` with the fo
 npm install mongodb-legacy
 ```
 
+	
+### Release Integrity
+
+The GitHub release contains a detached signature file for the NPM package (named
+`bson-X.Y.Z.tgz.sig`).
+
+The following command returns the link npm package. 
+```shell
+npm view mongodb@vX.Y.Z dist.tarball 
+```
+
+Using the result of the above command, a `curl` command can return the official npm package for the release.
+
+To verify the integrity of the downloaded package, run the following command:
+```shell
+gpg --verify mongodb-X.Y.Z.tgz.sig mongodb-X.Y.Z.tgz
+```
+
 ### Versioning
 
 We recommend replacing your `mongodb` dependency with this one.


### PR DESCRIPTION
### Description
Sign releases in legacy driver.

#### What is changing?
Automate release signing with a detached signature and verification instructions in the README.
[Link to an example of release signatures working with v2](https://github.com/mongodb/js-bson/actions/runs/9352138423/job/25739562707) (if you check the artifact link at the end of the compress_sign step, you can see the signature)

##### Is there new documentation needed for these changes?
No

#### What is the motivation for this change?
SSDLC Compliance

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Add Signature to Github Releases
The Github release for `mongodb-legacy` now contains a detached signature file for the NPM package (named
`mongodb-legacy-X.Y.Z.tgz.sig`), on every major and patch release.  To verify the signature, follow the instructions in the 'Release Integrity' section of the `README.md` file.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket