### PR TITLE
docs(NODE-6238): update release integrity section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -84,8 +84,9 @@ Using the result of the above command, a `curl` command can return the official 
 To verify the integrity of the downloaded package, run the following command:
 ```shell
 gpg --verify mongodb-legacy-X.Y.Z.tgz.sig mongodb-legacy-X.Y.Z.tgz
+```
 
-[!Note]
+>[!Note]
 No verification is done when using npm to install the package. The contents of the Github tarball and npm's tarball are identical.
 
 ```

--- a/readme.md
+++ b/readme.md
@@ -85,7 +85,7 @@ To verify the integrity of the downloaded package, run the following command:
 ```shell
 gpg --verify mongodb-legacy-X.Y.Z.tgz.sig mongodb-legacy-X.Y.Z.tgz
 
->[!Note]
+[!Note]
 No verification is done when using npm to install the package. The contents of the Github tarball and npm's tarball are identical.
 
 ```

--- a/readme.md
+++ b/readme.md
@@ -86,7 +86,7 @@ To verify the integrity of the downloaded package, run the following command:
 gpg --verify mongodb-legacy-X.Y.Z.tgz.sig mongodb-legacy-X.Y.Z.tgz
 
 >[!Note]
-No verification is done when using npm to install the package. To ensure release integrity when using npm, download the tarball manually from the GitHub release, verify the signature, then install the package from the downloaded tarball using `npm install mongodb-legacy-X.Y.Z.tgz`.
+No verification is done when using npm to install the package. The contents of the Github tarball and npm's tarball are identical.
 
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -65,6 +65,12 @@ npm install mongodb-legacy
 	
 ### Release Integrity
 
+Releases are created automatically and signed using the [Node team's GPG key](https://pgp.mongodb.com/node-driver.asc). This applies to the git tag as well as all release packages provided as part of a GitHub release. To verify the provided packages, download the key and import it using gpg:
+
+```
+gpg --import node-driver.asc
+```
+
 The GitHub release contains a detached signature file for the NPM package (named
 `mongodb-legacy-X.Y.Z.tgz.sig`).
 
@@ -78,6 +84,10 @@ Using the result of the above command, a `curl` command can return the official 
 To verify the integrity of the downloaded package, run the following command:
 ```shell
 gpg --verify mongodb-legacy-X.Y.Z.tgz.sig mongodb-legacy-X.Y.Z.tgz
+
+>[!Note]
+No verification is done when using npm to install the package. To ensure release integrity when using npm, download the tarball manually from the GitHub release, verify the signature, then install the package from the downloaded tarball using `npm install mongodb-legacy-X.Y.Z.tgz`.
+
 ```
 
 ### Versioning


### PR DESCRIPTION
### Description

Updates the release integrity section with links to the GPG key and npm note.

#### What is changing?

readme.md

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-6238

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
