### PR TITLE
fix(NODE-6328): pass through optional options in txn APIs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -62,7 +62,7 @@ In your existing project add `mongodb-legacy` to your `package.json` with the fo
 npm install mongodb-legacy
 ```
 
-	
+
 ### Release Integrity
 
 Releases are created automatically and signed using the [Node team's GPG key](https://pgp.mongodb.com/node-driver.asc). This applies to the git tag as well as all release packages provided as part of a GitHub release. To verify the provided packages, download the key and import it using gpg:
@@ -74,9 +74,9 @@ gpg --import node-driver.asc
 The GitHub release contains a detached signature file for the NPM package (named
 `mongodb-legacy-X.Y.Z.tgz.sig`).
 
-The following command returns the link npm package. 
+The following command returns the link npm package.
 ```shell
-npm view mongodb-legacy@vX.Y.Z dist.tarball 
+npm view mongodb-legacy@vX.Y.Z dist.tarball
 ```
 
 Using the result of the above command, a `curl` command can return the official npm package for the release.
@@ -86,10 +86,8 @@ To verify the integrity of the downloaded package, run the following command:
 gpg --verify mongodb-legacy-X.Y.Z.tgz.sig mongodb-legacy-X.Y.Z.tgz
 ```
 
->[!Note]
-No verification is done when using npm to install the package. The contents of the Github tarball and npm's tarball are identical.
-
-```
+>[!NOTE]
+> No verification is done when using npm to install the package. The contents of the Github tarball and npm's tarball are identical.
 
 ### Versioning
 

--- a/src/legacy_wrappers/session.js
+++ b/src/legacy_wrappers/session.js
@@ -7,12 +7,28 @@ Object.defineProperty(module.exports, '__esModule', { value: true });
 
 module.exports.makeLegacyClientSession = function (baseClass) {
   class LegacyClientSession extends baseClass {
-    abortTransaction(callback) {
-      return maybeCallback(super.abortTransaction(), callback);
+    abortTransaction(options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+            ? options
+            : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+
+      return maybeCallback(super.abortTransaction(options), callback);
     }
 
-    commitTransaction(callback) {
-      return maybeCallback(super.commitTransaction(), callback);
+    commitTransaction(options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+            ? options
+            : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+
+      return maybeCallback(super.commitTransaction(options), callback);
     }
 
     endSession(options, callback) {

--- a/test/tools/api.js
+++ b/test/tools/api.js
@@ -57,8 +57,8 @@ const api = [
   { className: 'ChangeStream', method: 'next', returnType: 'Promise<TChange>' },
   { className: 'ChangeStream', method: 'tryNext', returnType: 'Promise<Document | null>' },
 
-  { className: 'ClientSession', method: 'abortTransaction', returnType: 'Promise<Document>' },
-  { className: 'ClientSession', method: 'commitTransaction', returnType: 'Promise<Document>' },
+  { className: 'ClientSession', method: 'abortTransaction', returnType: 'Promise<Document>', possibleCallbackPositions: [1, 2] },
+  { className: 'ClientSession', method: 'commitTransaction', returnType: 'Promise<Document>', possibleCallbackPositions: [1, 2] },
   { className: 'ClientSession', method: 'endSession', returnType: 'Promise<void>' },
   { className: 'ClientSession', method: 'withTransaction', returnType: 'Promise<void>', notAsync: true },
 


### PR DESCRIPTION
### Description

#### What is changing?

- Add optional options pass through
- No public API changes

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

- The driver is adding an optional options object to these APIs we need to pass it through to enable it in our tests.

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Internal MongoDB Driver fix

> [!NOTE]
> A correction has been made to an API that is only relevant to driver internals. There are no public-facing API changes in this fix.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
