### PR TITLE
feat(NODE-6399): support new gridfs options arguments

### DIFF
--- a/src/legacy_wrappers/gridfs.js
+++ b/src/legacy_wrappers/gridfs.js
@@ -7,16 +7,37 @@ Object.defineProperty(module.exports, '__esModule', { value: true });
 
 module.exports.makeLegacyGridFSBucket = function (baseClass) {
   class LegacyGridFSBucket extends baseClass {
-    delete(id, callback) {
-      return maybeCallback(super.delete(id), callback);
+    delete(id, options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+            ? options
+            : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.delete(id, options), callback);
     }
 
-    rename(id, filename, callback) {
-      return maybeCallback(super.rename(id, filename), callback);
+    rename(id, filename, options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+            ? options
+            : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.rename(id, filename, options), callback);
     }
 
-    drop(callback) {
-      return maybeCallback(super.drop(), callback);
+    drop(options, callback) {
+      callback =
+        typeof callback === 'function'
+          ? callback
+          : typeof options === 'function'
+            ? options
+            : undefined;
+      options = typeof options !== 'function' ? options : undefined;
+      return maybeCallback(super.drop(options), callback);
     }
 
     // conversion

--- a/test/unit/legacy_wrappers/gridfs.test.js
+++ b/test/unit/legacy_wrappers/gridfs.test.js
@@ -48,4 +48,52 @@ describe('legacy_wrappers/gridfs.js', () => {
       LegacyGridFSBucketWriteStream
     );
   });
+
+  context('delete', function () {
+    it('correctly handles parameters when options are provided', function () {
+      const spy = sinon.spy(mongodbDriver.GridFSBucket.prototype, 'delete');
+      const opts = { timeoutMS: 10 };
+      const oid = new mongodbDriver.ObjectId();
+      bucket.delete(oid, opts, () => {});
+      expect(spy).to.be.calledWithExactly(oid, opts);
+    });
+    it('correctly handles parameters when options are not provided', function () {
+      const spy = sinon.spy(mongodbDriver.GridFSBucket.prototype, 'delete');
+      const oid = new mongodbDriver.ObjectId();
+      bucket.delete(oid, () => {});
+      expect(spy).to.be.calledWithExactly(oid, undefined);
+    });
+  });
+
+  context('rename', function () {
+    it('correctly handles parameters when options are provided', function () {
+      const spy = sinon.spy(mongodbDriver.GridFSBucket.prototype, 'rename');
+      const opts = { timeoutMS: 10 };
+      const oid = new mongodbDriver.ObjectId();
+      bucket.rename(oid, 'name', opts, () => {});
+      expect(spy).to.be.calledWithExactly(oid, 'name', opts);
+    });
+
+    it('correctly handles parameters when options are not provided', function () {
+      const spy = sinon.spy(mongodbDriver.GridFSBucket.prototype, 'rename');
+      const oid = new mongodbDriver.ObjectId();
+      bucket.rename(oid, 'name', () => {});
+      expect(spy).to.be.calledWithExactly(oid, 'name', undefined);
+    });
+  });
+
+  context('drop', function () {
+    it('correctly handles parameters when options are provided', function () {
+      const spy = sinon.spy(mongodbDriver.GridFSBucket.prototype, 'drop');
+      const opts = { timeoutMS: 10 };
+      bucket.drop(opts, () => {});
+      expect(spy).to.be.calledWithExactly(opts);
+    });
+
+    it('correctly handles parameters when options are not provided', function () {
+      const spy = sinon.spy(mongodbDriver.GridFSBucket.prototype, 'drop');
+      bucket.drop(() => {});
+      expect(spy).to.be.calledWithExactly(undefined);
+    });
+  });
 });


### PR DESCRIPTION
### Description

#### What is changing?
Added support for optional options argument in certain GridFSBucket methods

##### Is there new documentation needed for these changes?
No

#### What is the motivation for this change?

NODE-6399

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Support new options argument for `GridFSBucket`
We now support an optional `options` argument for `GridFSBucket.drop`, `GridFSBucket.delete` and `GridFSBucket.rename`.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [X] Ran `npm run check:lint` script
- [X] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [X] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [X] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
