### PR TITLE
docs(NODE-7275): mark package as deprecated as of V7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,18 +21,6 @@ jobs:
       - run: npm clean-install
       - run: npm run check:test
 
-  test-latest-driver:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Use Node.js LTS
-        uses: actions/setup-node@v4
-        with:
-          node-version: lts/*
-      - run: npm clean-install
-      - run: npm install --no-save mongodb/node-mongodb-native#main
-      - run: npm run check:test
-
   coverage:
     runs-on: ubuntu-latest
     steps:

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,8 @@
-# MongoDB Node.js Driver with Optional Callback Support Legacy Package
+# MongoDB Node.js Driver with Optional Callback Support Legacy Package (DEPRECATED)
 
 **Attention :memo:**
 
-This is a wrapper of the `mongodb` driver, if you are starting a new project you likely just want to use the driver directly:
+This is a wrapper of the `mongodb` driver, compatible with versions 4.x-6.x ONLY. There will be no 7.x+ compatible version. If you are starting a new project please use the driver directly:
 
 - [Driver Source](https://github.com/mongodb/node-mongodb-native/)
 - [Driver NPM Package](https://www.npmjs.com/package/mongodb)
@@ -102,6 +102,7 @@ The following version combinations with the [MongoDB Node.js Driver](https://git
 
 |               | `mongodb-legacy@4.x` | `mongodb-legacy@5.x` | `mongodb-legacy@6.x` |
 | ------------- | -------------------- | -------------------- | -------------------- |
+| `mongodb@7.x` | N/A                  | N/A                  | N/A                  |
 | `mongodb@6.x` | N/A                  | N/A                  | ✓                    |
 | `mongodb@5.x` | N/A                  | ✓                    | N/A                  |
 | `mongodb@4.x` | ✓                    | N/A                  | N/A                  |


### PR DESCRIPTION
### Description

#### Summary of Changes

Mark the package as deprecated as of the node driver V7 release and update the compat tables accordingly.

##### Notes for Reviewers

<!-- 
If there is any additional context on the changes in the PR that reviewers might find helpful, feel free to make notes in this section.

Otherwise, feel free to remove this section.
-->

#### What is the motivation for this change?

NODE-7275

### Double check the following

- [ ] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
